### PR TITLE
Better cv errors

### DIFF
--- a/R/Lrnr_cv.R
+++ b/R/Lrnr_cv.R
@@ -75,7 +75,7 @@ Lrnr_cv <- R6Class(classname = "Lrnr_cv",
 
                         cv_results=cross_validate(cv_train,folds,learner,task,.combine=F, future.globals=F)
 
-                        fit_object=list(folds=folds, fold_fits=cv_results$fold_fits, errors=cv_results$errors)
+                        fit_object=list(folds=folds, fold_fits=cv_results$fold_fit, errors=cv_results$errors)
 
                         return(fit_object)
                        },

--- a/R/Lrnr_cv.R
+++ b/R/Lrnr_cv.R
@@ -73,9 +73,9 @@ Lrnr_cv <- R6Class(classname = "Lrnr_cv",
                            return(list(fold_fit=fit_object))
                          }
 
-                        fold_fits=cross_validate(cv_train,folds,learner,task,.combine=F, future.globals=F)$fold_fit
+                        cv_results=cross_validate(cv_train,folds,learner,task,.combine=F, future.globals=F)
 
-                        fit_object=list(folds=folds, fold_fits=fold_fits)
+                        fit_object=list(folds=folds, fold_fits=cv_results$fold_fits, errors=cv_results$errors)
 
                         return(fit_object)
                        },

--- a/tests/testthat/test_cv_broken.R
+++ b/tests/testthat/test_cv_broken.R
@@ -22,4 +22,4 @@ broken_cv <- Lrnr_cv$new(broken_learner)
 
 broken_fit <- broken_cv$train(task)
 errors <- broken_fit$fit_object$errors$error
-lapply(errors, attr, "condition")
+expect_true(all(errors == "Error in private$.train(subsetted_task) : \n  this task always returns an error\n"))

--- a/tests/testthat/test_cv_broken.R
+++ b/tests/testthat/test_cv_broken.R
@@ -1,0 +1,25 @@
+library(sl3)
+library(R6)
+
+data(cpp)
+cpp <- cpp[!is.na(cpp[, "haz"]), ]
+covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs", "sexn")
+cpp[is.na(cpp)] <- 0
+outcome <- "haz"
+task <- sl3_Task$new(cpp, covariates = covars, outcome = outcome)
+
+
+Lrnr_broken <- R6Class(classname = "Lrnr_broken", inherit = Lrnr_base, portable = TRUE, 
+                       public=list(),
+                       private=list(
+                         .train=function(task){
+                           stop("this task always returns an error")
+                         }))
+
+broken_learner <- Lrnr_broken$new()
+
+broken_cv <- Lrnr_cv$new(broken_learner)
+
+broken_fit <- broken_cv$train(task)
+errors <- broken_fit$fit_object$errors$error
+lapply(errors, attr, "condition")


### PR DESCRIPTION
Errors are now captured in the `fit_object` returned from `Lrnr_cv` `test_cv_broken.R` illustrates its usage. In response to https://github.com/jeremyrcoyle/sl3/issues/54