### PR TITLE
implementing SE for learner risk in Lrnr_sl; clean-up print for Lrnr_sl

### DIFF
--- a/R/Lrnr_sl.R
+++ b/R/Lrnr_sl.R
@@ -13,46 +13,63 @@ Lrnr_sl <- R6Class(classname = "Lrnr_sl",
                        if(inherits(learners,"Stack")){
                          learners <- learners$params$learners
                        }
-                       
+
                        params=list(learners=learners, metalearner=metalearner, folds=folds, ...)
                        super$initialize(params=params, ...)
                      },
                      print = function(){
-                       print("SuperLearner")
-                       print(self$params$learners)
-                       
+                       lrn_names <- lapply(self$params$learners, function(obj) obj$name)
+                       print("SuperLearner:"); str(lrn_names)
                        if(self$is_trained){
-                         print(private$.fit_object)
+                         fit_object <- private$.fit_object
+                         print(fit_object$cv_meta_fit)
+                         print("Cross-validated risk (MSE, squared error loss):")
+                         print(self$cv_risk(loss_squared_error))
                        }
                      },
                      metalearner_fit = function(){
                        self$assert_trained()
                        return(private$.fit_object$cv_meta_fit$fit_object)
                      },
+
                      cv_risk = function(loss_fun){
-                       warning("cv_risks are for demonstration purposes only. Don't trust these for now")
+                       # warning("cv_risks are for demonstration purposes only. Don't trust these for now")
                        cv_meta_task <- self$fit_object$cv_meta_task
                        cv_meta_fit <- self$fit_object$cv_meta_fit
                        losses <- cv_meta_task$X[,lapply(.SD,loss_fun,cv_meta_task$Y)]
                        losses[, SuperLearner:=loss_fun(cv_meta_fit$predict(),cv_meta_task$Y)]
-                       
+
+                       ## multiply each loss (L(O_i)) by the weights (w_i):
+                       losses_by_id <- losses[, lapply(.SD, function(loss) cv_meta_task$weights * loss)]
+                       ## for clustered data, this will first evaluate the mean weighted loss within each cluster (subject) before evaluating sd
+                       losses_by_id <- losses_by_id[, lapply(.SD, function(loss) mean(loss, na.rm = TRUE)), by = cv_meta_task$id]
+                       losses_by_id[, "cv_meta_task" := NULL]
+                       ## n_obs for clustered data (person-time observations), should be equal to number of indep. subjects
+                       n_obs <- nrow(losses_by_id)
+                       ## eval risk SE for each learner incorporating: a) weights and b) using the number of indep subjects
+                       se <- unlist((1 / sqrt(n_obs)) * losses_by_id[, lapply(.SD, sd, na.rm = TRUE)])
+
                        #get fold specific risks
                        validation_means <- function(fold, losses,weight){
                          risks <- lapply(validation(losses), weighted.mean, validation(weight))
                          return(list(risks=as.data.frame(risks)))
                        }
-                       
+
                        #todo: this ignores weights, square errors are also incorrect
                        fold_risks <- cross_validate(validation_means, cv_meta_task$folds, losses, cv_meta_task$weights)$risks
-                       mean_risks <- apply(fold_risks,2,mean)
-                       max_risks <- apply(fold_risks,2,max)
-                       min_risks <- apply(fold_risks,2,min)
-                       se <- apply(fold_risks, 2, sd)
-                       
+                       fold_mean_risk <- apply(fold_risks,2,mean)
+                       fold_min_risk <- apply(fold_risks,2,min)
+                       fold_max_risk <- apply(fold_risks,2,max)
+                       fold_SD <- apply(fold_risks,2,sd)
 
                        learner_names <- c(sapply(self$params$learners, "[[","name"),"SuperLearner")
-                       risk_dt <- data.table::data.table(learner=learner_names, mean=mean_risks, se=se, min=min_risks,max=max_risks)
-                       
+                       risk_dt <- data.table::data.table(learner=learner_names,
+                                                         mean_risk=fold_mean_risk,
+                                                         SE_risk=se,
+                                                         fold_SD=fold_SD,
+                                                         fold_min_risk=fold_min_risk,
+                                                         fold_max_risk=fold_max_risk)
+
                        return(risk_dt)
                      }
                    ),
@@ -69,43 +86,43 @@ Lrnr_sl <- R6Class(classname = "Lrnr_sl",
                          #todo: this breaks if task is delayed
                          folds <- task$folds
                        }
-                       
+
                        #make stack and cv learner objects
                        learners <- self$params$learners
                        learner_stack <- do.call(Stack$new,learners)
                        cv_stack <- Lrnr_cv$new(learner_stack, folds=folds)
-                       
+
                        #fit stack on cv data
                        cv_fit <- delayed_learner_train(cv_stack, task)
-                       
+
                        #fit metalearner
                        metalearner <- self$params$metalearner
                        cv_meta_task <- delayed_learner_fit_chain(cv_fit,task)
                        cv_meta_fit <- delayed_learner_train(metalearner, cv_meta_task)
-                       
+
                        #refit stack on full data
                        stack_fit <- delayed_learner_train(learner_stack, task)
-                       
+
                        #form full SL fit -- a pipeline with the stack fit to the full data,
                        #and the metalearner fit to the cv predictions
                        full_fit <- delayed_learner_new(Pipeline,stack_fit,cv_meta_fit)
-                       
-                       
+
+
                        fit_object <- list(cv_meta_task=cv_meta_task, cv_meta_fit=cv_meta_fit, full_fit=full_fit)
                        return(bundle_delayed(fit_object))
 
                      },
                      .train = function(task, pretrain) {
-                       
+
                        return(pretrain)
                      },
-                     
+
                      .predict = function(task){
                        predictions=private$.fit_object$full_fit$predict(task)
                        return(predictions)
                      }
-                     
+
                    )
-                   
+
 )
 

--- a/tests/testthat/test_sl.R
+++ b/tests/testthat/test_sl.R
@@ -20,7 +20,7 @@ subset_apgar <- Lrnr_subset_covariates$new(covariates=c("apgar1","apgar5"))
 sl1 <- Lrnr_sl$new(learners = list(glm_learner, glmnet_learner, subset_apgar), metalearner = glm_learner)
 
 sl1_fit <- sl1$train(task)
-expected_learners <- c("Lrnr_glm", "Lrnr_pkg_SuperLearner_SL.glmnet", "Lrnr_subset_covariates_c(\"apgar1\", \"apgar5\")_apgar1", 
+expected_learners <- c("Lrnr_glm", "Lrnr_pkg_SuperLearner_SL.glmnet", "Lrnr_subset_covariates_c(\"apgar1\", \"apgar5\")_apgar1",
                        "Lrnr_subset_covariates_c(\"apgar1\", \"apgar5\")_apgar5")
 test_that("sl1_fit is based on the right learners", expect_equal(sl1_fit$fit_object$cv_meta_task$nodes$covariates,expected_learners))
 
@@ -34,7 +34,7 @@ sl2 <- Lrnr_sl$new(learners = stack, metalearner = glm_learner)
 sl2_fit <- sl2$train(task)
 suppressWarnings({sl2_risk <- sl2_fit$cv_risk(loss_squared_error) })
 
-test_that("Lrnr_sl can accept a pre-made stack", expect_equal(sl1_risk$mean,sl2_risk$mean, tolerance = 1e-2))
+test_that("Lrnr_sl can accept a pre-made stack", expect_equal(sl1_risk$mean_risk,sl2_risk$mean_risk, tolerance = 1e-2))
 
 sl_nnls <- Lrnr_sl$new(learners = list(glm_learner, glmnet_learner), metalearner = sl3::Lrnr_nnls$new())
 sl_nnls_fit <- sl_nnls$train(task)


### PR DESCRIPTION
This attempts to clean-up the print method of the `Lrnr_sl` object. 

Among the important additions is the table with learner-specific CV-risks (using squared-error loss by default), along with standard error estimates of the CV-risk (allows constructing CI for cross-validated MSE). 

The risk estimates and SEs are weighed (when external weights were specified). The SEs are evaluated by first averaging the risk with each cluster/id, then evaluating SD across independent subjects. 

Ideally, it would be nice to verify that this is working as expected in a simulation. 

```
> sl_nnls <- Lrnr_sl$new(learners = list(glm_learner, glmnet_learner), metalearner = sl3::Lrnr_nnls$new())
> sl_nnls_fit <- sl_nnls$train(task)
> print(sl_nnls_fit)
[1] "SuperLearner:"
List of 2
 $ : chr "Lrnr_glm"
 $ : chr "Lrnr_pkg_SuperLearner_SL.glmnet"
[1] "Lrnr_nnls"
                             lrnrs   weights
1:                        Lrnr_glm 0.7116500
2: Lrnr_pkg_SuperLearner_SL.glmnet 0.2007182
[1] "Cross-validated risk (MSE, squared error loss):"
                           learner mean_risk   SE_risk   fold_SD fold_min_risk fold_max_risk
1:                        Lrnr_glm  1.597564 0.1038691 0.3060019      1.229615      2.141139
2: Lrnr_pkg_SuperLearner_SL.glmnet  1.597228 0.1035116 0.3016594      1.230024      2.138036
3:                    SuperLearner  1.596682 0.1035193 0.3045437      1.230151      2.139700
```