### PR TITLE
variable_type improvements

### DIFF
--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -48,6 +48,11 @@ Lrnr_base <- R6Class(classname = "Lrnr_base",
                            # learners can override task outcome type
                            outcome_type <- self$params$outcome_type
                          }
+                         
+                         # make sure outcome type is a variable_type object
+                         if(is.character(outcome_type)){
+                           outcome_type <- variable_type(type = outcome_type, x = task$Y)
+                         } 
 
                          return(outcome_type)
                        },

--- a/R/Variable_Type.R
+++ b/R/Variable_Type.R
@@ -4,7 +4,7 @@ Variable_Type <- R6Class(classname = "Variable_Type",
                          portable = TRUE,
                          class = TRUE,
                          public = list(
-                           initialize = function(type = NULL, levels = NULL, bounds = NULL, x = NULL, pcontinuous = 0.05){
+                           initialize = function(type = NULL, levels = NULL, bounds = NULL, x = NULL, pcontinuous = getOption("sl3.pcontinuous")){
                              if(is.null(type)){
                                if(is.null(x)){
                                  stop("type not specified, and no x from which to infer it")
@@ -120,7 +120,7 @@ Variable_Type <- R6Class(classname = "Variable_Type",
 #' @param x data to use for inferring type if not specified
 #' @param pcontinuous if type inferred, proportion of unique observations above which variable is continuous
 #' @export
-variable_type <- function(type = NULL, levels = NULL, bounds = NULL, x = NULL, pcontinuous = 0.05){
+variable_type <- function(type = NULL, levels = NULL, bounds = NULL, x = NULL, pcontinuous = getOption("sl3.pcontinuous")){
   return(Variable_Type$new(type = type, levels = levels, bounds = bounds, x = x, pcontinuous = pcontinuous))
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -49,7 +49,8 @@ sl3Options <- function (o, value)  {
               # sl3.file.name  = 'sl3-report-%T-%N-%n'
               "sl3.file.name"  = paste0('sl3-report-', Sys.Date()),
               "sl3.memoise.learner" = FALSE,
-              "sl3.save.training" = TRUE
+              "sl3.save.training" = TRUE,
+              "sl3.pcontinuous" = 0.05
             )
   # for (i in setdiff(names(opts),names(options()))) {
   #   browser()

--- a/man/variable_type.Rd
+++ b/man/variable_type.Rd
@@ -10,7 +10,7 @@
 Variable_Type
 
 variable_type(type = NULL, levels = NULL, bounds = NULL, x = NULL,
-  pcontinuous = 0.05)
+  pcontinuous = getOption("sl3.pcontinuous"))
 }
 \arguments{
 \item{type}{A type name}

--- a/tests/testthat/test_variable_type.R
+++ b/tests/testthat/test_variable_type.R
@@ -58,3 +58,22 @@ test_that("outcome levels are binarized for outcome_type binomial",{
   expect_true(all(Y_binomial%in%c(0,1)))
   expect_equal(Y_binomial, as.numeric(task$Y==max(levels(task$Y))))
 })
+
+fglm_learner <- Lrnr_glm_fast$new(outcome_type = "continuous")
+test_that("outcome type can be passed to a task as a character", {
+  fglm_learner$train(task)
+})
+
+pcontinuous_default <- getOption("sl3.pcontinuous")
+test_that("pcontinuous uses sl3.pcontinuous option by default", {
+  options(sl3.pcontinuous=0)
+  type_1 <- variable_type(x=rep(rnorm(3),100))
+  expect_equal(type_1$type, "continuous")
+  
+  options(sl3.pcontinuous=1)
+  type_2 <- variable_type(x=rep(rnorm(3),100))
+  expect_equal(type_2$type, "categorical")
+  
+})
+
+options(sl3.pcontinuous=pcontinuous_default)


### PR DESCRIPTION
Two improvements to variable_type handling:

* Tasks now accept a character for `outcome_type`, automatically converting it to a `variable_type` object. (Addresses https://github.com/jeremyrcoyle/sl3/issues/93)
* A new option, `sl3.pcontinuous`, can be used to set the threshold above which a variable is determined to be continuous.

Tests added to confirm these changes.
