### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/README-norefs.Rmd
+++ b/README-norefs.Rmd
@@ -149,7 +149,7 @@ After using the `sl3` R package, please cite the following:
             Learning}},
           year  = {2017},
           howpublished = {\url{https://github.com/jeremyrcoyle/sl3}},
-          url = {http://dx.doi.org/DOI_HERE},
+          url = {https://doi.org/DOI_HERE},
           doi = {DOI_HERE}
         }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -139,7 +139,7 @@ After using the `sl3` R package, please cite the following:
             Learning}},
           year  = {2017},
           howpublished = {\url{https://github.com/jeremyrcoyle/sl3}},
-          url = {http://dx.doi.org/DOI_HERE},
+          url = {https://doi.org/DOI_HERE},
           doi = {DOI_HERE}
         }
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI links.

Cheers!