### PR TITLE
fix PCA bug: use test data correctly

### DIFF
--- a/R/Lrnr_pca.R
+++ b/R/Lrnr_pca.R
@@ -47,9 +47,9 @@ Lrnr_pca <- R6Class(
   class = TRUE,
   public = list(
     initialize = function(n_comp = 2,
-                          center = TRUE,
-                          scale. = TRUE,
-                          ...) {
+                              center = TRUE,
+                              scale. = TRUE,
+                              ...) {
       params <- args_to_list()
       super$initialize(params = params, ...)
     }
@@ -65,15 +65,19 @@ Lrnr_pca <- R6Class(
 
       # remove n_comp argument before calling stats::prcomp
       fit_object <- call_with_args(stats::prcomp, fit_args,
-                                   other_valid = list("retx", "center",
-                                                      "scale.", "tol", "rank.")
-                                  )
+        other_valid = list(
+          "retx", "center",
+          "scale.", "tol", "rank."
+        )
+      )
       return(fit_object)
     },
     .predict = function(task = NULL) {
       # note that n_comp is an argument not defined in stats::prcomp
       dim_args <- self$params[names(self$params) == "n_comp"]
-      preds_pca <- private$.fit_object$x[, seq_len(unlist(dim_args))]
+      preds_rotations <-
+        private$.fit_object$rotation[, seq_len(unlist(dim_args))]
+      preds_pca <- as.matrix(task$X) %*% preds_rotations
       predictions <- preds_pca
       return(predictions)
     },

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -44,8 +44,10 @@ test_that("Regression on PCs matches between Pipeline and manual invocation.", {
 
 test_that("Arguments are passed to prcomp correctly by Lrnr_pca", {
   # pass some arguments to prcomp via Lrnr_pca
-  pca_sl3 <- Lrnr_pca$new(n_comp = ncomp, retx = FALSE, center = TRUE,
-                          scale. = FALSE)
+  pca_sl3 <- Lrnr_pca$new(
+    n_comp = ncomp, retx = FALSE, center = TRUE,
+    scale. = FALSE
+  )
   pcr_pipe_sl3 <- Pipeline$new(pca_sl3, glm_fast)
   pcr_pipe_sl3_fit <- pcr_pipe_sl3$train(task)
   pca_from_pipe <- pcr_pipe_sl3_fit$fit_object$learner_fits[[1]]$fit_object
@@ -57,4 +59,3 @@ test_that("Arguments are passed to prcomp correctly by Lrnr_pca", {
 
   expect_equal(pca_from_pipe, cpp_pca)
 })
-


### PR DESCRIPTION
This PR fixes a bug in `Lrnr_pca` so that data from a test set is utilized properly. This means that predicting from a trained pipeline using a test data `sl3_Task` will now work properly.