### PR TITLE
force undelay task in Lrnr_cv

### DIFF
--- a/R/Lrnr_cv.R
+++ b/R/Lrnr_cv.R
@@ -146,10 +146,16 @@ Lrnr_cv <- R6Class(
     .properties = c("wrapper", "cv"),
 
     .train_sublearners = function(task) {
+      
+      # if we get a delayed task, evaluate it
+      # TODO: this is a kludge -- ideally we'd have Lrnr_cv work on delayed tasks like other learners
+      if(inherits(task,"Delayed")){
+        task <- task$compute()
+      }
+      
       # prefer folds from params, but default to folds from task
       folds <- self$params$folds
       if (is.null(folds)) {
-        # TODO: this breaks if task is delayed
         folds <- task$folds
       }
       learner <- self$params$learner


### PR DESCRIPTION
Fixes issues with Lrnr_cv by forcing the task to be computed (removing the delayed). This means that Lrnr_cv acts a bit different from other learners