### PR TITLE
Reduce haldensify testing overhead

### DIFF
--- a/tests/testthat/test-haldensify.R
+++ b/tests/testthat/test-haldensify.R
@@ -25,6 +25,7 @@ covars <- c(
 )
 outcome <- "haz"
 task <- cpp_imputed %>%
+  dplyr::slice(seq(1, nrow(.), by = 3)) %>%
   dplyr::filter(agedays == 1) %>%
   sl3_Task$new(
     covariates = covars,
@@ -61,26 +62,26 @@ test_that("Lrnr_haldensify produces predictions identical to haldensify", {
   expect_equal(hal_dens_preds, haldensify_preds, tolerance = 1e-15)
 })
 
-test_that("Ensembling with Lrnr_haldensify produces sane predictions", {
-  # just another HAL to ensemble with
-  hal_dens2 <- Lrnr_haldensify$new(
-    grid_type = "equal_range",
-    n_bins = 5,
-    lambda_seq = exp(seq(-1, -12, length = 100))
-  )
+#test_that("Ensembling with Lrnr_haldensify produces sane predictions", {
+  ## just another HAL to ensemble with
+  #hal_dens2 <- Lrnr_haldensify$new(
+    #grid_type = "equal_range",
+    #n_bins = 5,
+    #lambda_seq = exp(seq(-1, -12, length = 100))
+  #)
 
-  # ensemble-based conditional density estimation
-  sl3_dens <- Lrnr_sl$new(
-    learners = list(hal_dens, hal_dens2),
-    metalearner = Lrnr_solnp_density$new()
-  )
+  ## ensemble-based conditional density estimation
+  #sl3_dens <- Lrnr_sl$new(
+    #learners = list(hal_dens, hal_dens2),
+    #metalearner = Lrnr_solnp_density$new()
+  #)
 
-  set.seed(67391)
-  sl3_dens_fit <- sl3_dens$train(task)
-  sl3_dens_preds <- sl3_dens_fit$predict() %>%
-    unlist(use.names = FALSE)
+  #set.seed(67391)
+  #sl3_dens_fit <- sl3_dens$train(task)
+  #sl3_dens_preds <- sl3_dens_fit$predict() %>%
+    #unlist(use.names = FALSE)
 
-  # check that predicted conditional density estimates are sane
-  # expect_gte(min(range(sl3_dens_preds)), 0)
-  # expect_lte(max(range(sl3_dens_preds)), 1)
-})
+  ## check that predicted conditional density estimates are sane
+  #expect_gte(min(range(sl3_dens_preds)), 0)
+  #expect_lte(max(range(sl3_dens_preds)), 1)
+#})


### PR DESCRIPTION
* use deterministic subsetting in `haldensify` test
* disable Super Learner-based `haldensify` test due to speed