### PR TITLE
check for full-fit errors when checking stack errors

### DIFF
--- a/R/Lrnr_cv.R
+++ b/R/Lrnr_cv.R
@@ -198,7 +198,12 @@ Lrnr_cv <- R6Class(
       if (inherits(learner, "Stack")) {
         # if we're cross-validating a stack, check for learner errors in any
         # folds and then drop for all folds
-        errored_learners <- sapply(fold_fits, function(fold_fit) {
+        all_fits <- fold_fits
+        if (self$params$full_fit) {
+          all_fits <- c(all_fits, full_fit)
+        }
+        
+        errored_learners <- sapply(all_fits, function(fold_fit) {
           fold_fit$fit_object$is_error
         })
         if (is.vector(errored_learners)) {
@@ -213,6 +218,11 @@ Lrnr_cv <- R6Class(
           for (fold_fit in fold_fits) {
             fold_fit$update_errors(ever_error)
           }
+          
+          if (self$params$full_fit) {
+            full_fit$update_errors(ever_error)
+          }
+          
           # warn about dropping
           errored_learners <- learner$params$learners[ever_error]
           errored_names <- sapply(errored_learners, `[[`, "name")

--- a/R/Lrnr_sl.R
+++ b/R/Lrnr_sl.R
@@ -147,10 +147,6 @@ Lrnr_sl <- R6Class(
       cv_meta_task <- delayed_learner_fit_chain(cv_fit, task)
       cv_meta_fit <- delayed_learner_train(metalearner, cv_meta_task)
 
-      # refit stack on full data
-      full_task <- task$revere_fold_task("full")
-      stack_fit <- delayed_learner_train(learner_stack, full_task)
-
       # form full SL fit -- a pipeline with the stack fit to the full data,
       # and the metalearner fit to the cv predictions
       fit_object <- list(
@@ -166,10 +162,6 @@ Lrnr_sl <- R6Class(
       # construct full fit pipeline
       full_stack_fit <- fit_object$cv_fit$fit_object$full_fit
       full_stack_fit$custom_chain(drop_offsets_chain)
-
-      # propagate stack errors from cross-validation to full refit
-      cv_errors <- fit_object$cv_fit$fit_object$is_error
-      full_stack_fit$update_errors(cv_errors)
 
       full_fit <- make_learner(Pipeline, full_stack_fit, fit_object$cv_meta_fit)
 


### PR DESCRIPTION
`Lrnr_cv` detects if its internal learner is a `Stack` and if so, it checks the stack fit on all folds for errors, and drops learners that error on any fold. It wasn't doing this for the final `full_fit`. Now it also checks the final `full_fit`, and drops learners that error on any fold OR on the final `full_fit`