### PR TITLE
fix nrow

### DIFF
--- a/R/Lrnr_arima.R
+++ b/R/Lrnr_arima.R
@@ -66,7 +66,7 @@ Lrnr_arima <- R6Class(
       n.ahead <- params[["n.ahead"]]
 
       if (is.null(n.ahead)) {
-        n.ahead <- nrow(task$X)
+        n.ahead <- task$nrow
       }
       predictions <- predict(
         private$.fit_object,

--- a/R/Lrnr_expSmooth.R
+++ b/R/Lrnr_expSmooth.R
@@ -104,7 +104,7 @@ Lrnr_expSmooth <- R6Class(
       n.ahead <- params[["n.ahead"]]
 
       if (is.null(n.ahead)) {
-        n.ahead <- nrow(task$X)
+        n.ahead <- task$nrow
       }
       predictions <- forecast::forecast(private$.fit_object, h = n.ahead)
       # Create output as in glm

--- a/R/Lrnr_harmonicReg.R
+++ b/R/Lrnr_harmonicReg.R
@@ -71,7 +71,7 @@ Lrnr_HarmonicReg <- R6Class(
       Kparam <- params[["Kparam"]]
 
       if (is.null(n.ahead)) {
-        n.ahead <- nrow(task$X)
+        n.ahead <- task$nrow
       }
 
       task_ts <- ts(task$X, frequency = freq)

--- a/R/Lrnr_rugarch.R
+++ b/R/Lrnr_rugarch.R
@@ -77,7 +77,7 @@ Lrnr_rugarch <- R6Class(
       params <- self$params
       n.ahead <- params[["n.ahead"]]
       if (is.null(n.ahead)) {
-        n.ahead <- nrow(task$X)
+        n.ahead <- task$nrow
       }
       # Give the same output as GLM
       predictions <- rugarch::ugarchforecast(

--- a/R/Lrnr_tsDyn.R
+++ b/R/Lrnr_tsDyn.R
@@ -157,7 +157,7 @@ Lrnr_tsDyn <- R6Class(
       learner <- params[["learner"]]
 
       if (is.null(n.ahead)) {
-        n.ahead <- nrow(task$X)
+        n.ahead <- task$nrow
       }
       if (learner == "TVAR") {
         stop("No forecast for multivariate Threshold VAR model implemented.")

--- a/R/Stack.R
+++ b/R/Stack.R
@@ -134,7 +134,7 @@ Stack <- R6Class(
       learner_fits <- private$.fit_object$learner_fits[!is_error]
       learners <- self$params$learners[!is_error]
       learner_names <- private$.learner_names
-      n_to_pred <- nrow(task$X)
+      n_to_pred <- task$nrow
       n_learners <- length(learner_names)
 
       ## Cannot use := to add columns to a null data.table (no columns),


### PR DESCRIPTION
Several learners used `nrow(task$X)` to get the number of observations. This breaks for tasks without covariates. The more general `task$nrow` was substituted