### PR TITLE
don't count NA as a value when guessing variable types from data

### DIFF
--- a/R/Variable_Type.R
+++ b/R/Variable_Type.R
@@ -13,7 +13,7 @@ Variable_Type <- R6Class(
         if (is.null(x)) {
           stop("type not specified, and no x from which to infer it")
         }
-        nunique <- length(unique(x))
+        nunique <- length(na.exclude(unique(x)))
         if (!is.null(ncol(x))) {
           type <- "multivariate"
         } else if (nunique == 1) {

--- a/tests/testthat/test-variable_type.R
+++ b/tests/testthat/test-variable_type.R
@@ -17,6 +17,7 @@ test_that(
   expect_equal(type_names, expected_variable_types)
 )
 
+variable_type(x=c(0,0,1,1,NA,0))
 
 # forcing outcome_type
 data(cpp)


### PR DESCRIPTION
Previously, NA would count as a unique value when counting values for the variable type process. This causes problems, for example, when data takes on values c(0,1,NA). Previously this was 3 unique values, considered categorical data. It is now 2 unique values, considered binomial data.