### PR TITLE
Overhaul data preprocessing

### DIFF
--- a/R/Shared_Data.R
+++ b/R/Shared_Data.R
@@ -7,15 +7,19 @@ Shared_Data <- R6Class(
   portable = TRUE,
   class = TRUE,
   public = list(
-    initialize = function(data, ...) {
+    initialize = function(data, force_copy = TRUE, ...) {
       if (inherits(data, "Shared_Data")) {
         stop("Shared_Data passed another Shared_Data object on construction.
               Instead of doing this, use the existing Shared_Data object.")
       }
 
       if (inherits(data, "data.table")) {
-        # explicitly copy existing data.table
-        private$.data <- data.table::copy(data)
+        if(force_copy){
+          # explicitly copy existing data.table
+          private$.data <- data.table::copy(data)
+        } else {
+          private$.data <- data
+        }
       } else {
         # coerce to data.table
         # as.data.table will also copy

--- a/R/Variable_Type.R
+++ b/R/Variable_Type.R
@@ -13,7 +13,7 @@ Variable_Type <- R6Class(
         if (is.null(x)) {
           stop("type not specified, and no x from which to infer it")
         }
-        nunique <- length(unique(x))
+        nunique <- length(na.exclude(unique(x)))
         if (!is.null(ncol(x))) {
           type <- "multivariate"
         } else if (nunique == 1) {

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -1,69 +1,86 @@
 #' @importFrom imputeMissings impute
-process_data <- function(data, covariates, outcome = NULL, column_names = NULL, flag = TRUE, save_flag_cols = TRUE, drop_missing_outcome = FALSE) {
-  # for efficiency, character & missing processing are not seperated
-  if (!is.null(column_names)) {
-    covariates_data <- sapply(covariates, function(s) column_names[[s]])
-    outcome_data <- sapply(outcome, function(s) column_names[[s]])
-  } else {
-    covariates_data <- covariates
-    outcome_data <- outcome
+process_data <- function(data, nodes, column_names, flag = TRUE, drop_missing_outcome = FALSE) {
+  
+  # force a copy so we can mutate data in place w/o distrupting a user's data
+  if(inherits(data, "data.table")){
+    data <- data.table::copy(data)
+  } else{
+    data <- as.data.table(data)
   }
+  
+  all_nodes <- unlist(nodes)
 
-  data <- data.table(data)
-  covars <- data[, colnames(data) %in% covariates_data, with = FALSE]
-  origin_cols <- colnames(data)
-  convert_cols <- vector()
+  
+  if(length(all_nodes)==0){
+    return(list(data = data, nodes = nodes, column_names = column_names))
+  }
+  node_columns <- unlist(column_names[all_nodes])
+  covariates_columns <- unlist(column_names[nodes$covariates])
+  outcome_columns <- unlist(column_names[nodes$outcome])
 
   factorized <- FALSE
   dropped <- FALSE
   imputed <- FALSE
 
   # process characters
-  char_cols <- names(which(sapply(covars, data.class) == "character"))
+  is_character <- which(data[ , sapply(.SD, is.character), .SDcols = node_columns])
+  char_cols <- node_columns[is_character]
+  char_vars <- all_nodes[is_character]
   if (length(char_cols) > 0) {
     warning(sprintf(
       "Character covariates found: %s;\nConverting these to factors",
-      paste0(char_cols, collapse = ", ")
+      paste0(char_vars, collapse = ", ")
     ))
+    
     # convert data
-    `for`(s, char_cols, `=`(covars[[s]], factor(covars[[s]])))
-    # convert names
-    convert_cols <- sapply(char_cols, function(s) paste0(s, "_factorized"))
-    names(convert_cols) <- char_cols
-
+    for(char_col in char_cols){
+      set(data, , char_col, as.factor(unlist(data[,char_col, with=FALSE])))
+    }
     factorized <- TRUE
   }
 
   # process missing
-  miss_cols <- names(which(sapply(
-    covars,
-    function(l) TRUE %in% is.na(l)
-  ) == TRUE))
-  missing_Y <- (!is.null(outcome) && any(is.na(data[, outcome_data, with = FALSE])))
+  has_missing <- data[ , sapply(.SD, function(x)any(is.na(x))), .SDcols = node_columns]
+  miss_cols <- node_columns[has_missing]
+  miss_vars <- all_nodes[has_missing]
+  
+  missing_Y <- any(nodes$outcome%in%miss_vars)
+  missing_covar_cols <- intersect(miss_cols, covariates_columns)
+  missing_covar_vars <- intersect(miss_vars, nodes$covariates)
+  
   if (length(miss_cols) > 0) {
     if (missing_Y && drop_missing_outcome) {
       warning("Missing outcome data detected: dropping outcomes.")
-      keep_rows <- stats::complete.cases(data[, outcome_data, with = FALSE])
-      covars <- covars[keep_rows, ]
+      keep_rows <- stats::complete.cases(data[, outcome_columns, with = FALSE])
       data <- data[keep_rows, ]
-      dropped <- TRUE
-    }
-    warning("Missing covariate data detected: imputing covariates.")
-    # convert data
-    covars <- impute(covars, flag = flag)
-    # convert names
-    for (s in miss_cols) {
-      if (s %in% char_cols) {
-        convert_cols[s] <- paste0(convert_cols[s], "_imputed")
-      } else {
-        convert_cols <- stats::setNames(
-          c(convert_cols, paste0(s, "_imputed")),
-          c(names(convert_cols), s)
-        )
-      }
     }
 
-    missing_Y <- (!is.null(outcome) && any(is.na(data[, outcome_data, with = FALSE])))
+    if(length(missing_covar_cols)>0){
+      warning("Missing covariate data detected: imputing covariates.")
+      if (flag) {
+        # make indicators and add to data
+        missing_indicators <- data[, lapply(.SD, function(x) as.numeric(!is.na(x))),
+          .SDcols = missing_covar_cols
+        ]
+  
+        missing_indicator_cols <- sprintf("delta_%s", missing_covar_cols)
+        missing_indicator_vars <- sprintf("delta_%s", missing_covar_vars)
+  
+        setnames(missing_indicators, missing_indicator_cols)
+        set(data, , missing_indicator_cols, missing_indicators)
+  
+        # add inidicators to column map and covariate list
+        column_names[missing_indicator_vars] <- missing_indicator_cols
+        nodes$covariates <- c(nodes$covariates, missing_indicator_vars)
+      }
+      # impute covariates
+      imputed <- impute(data[, missing_covar_cols, with = FALSE], flag = FALSE)
+  
+      # update data
+      set(data, , missing_covar_cols, imputed)
+    }
+    
+    missing_Y <- (!is.null(nodes$outcome) && any(is.na(data[, outcome_columns, with = FALSE])))
     imputed <- TRUE
   }
 
@@ -71,32 +88,6 @@ process_data <- function(data, covariates, outcome = NULL, column_names = NULL, 
     warning("Missing outcome data detected. This is okay for prediction, but will likely break training. \n You can drop observations with missing outcomes by setting drop_missing_outcome=TRUE in make_sl3_Task.")
   }
 
-  # add new columns to data
-  if (length(convert_cols) > 0) {
-    `for`(i, 1:length(convert_cols), `=`(
-      data[[convert_cols[i]]],
-      covars[[names(convert_cols)[i]]]
-    ))
-
-    if (length(covars) > length(covariates)) {
-      flag_cols <- colnames(covars)[!(colnames(covars) %in% covariates_data)]
-      `for`(s, flag_cols, `=`(data[[s]], covars[[s]]))
-      `if`(save_flag_cols, `=`(covariates, c(covariates, flag_cols)))
-    }
-  }
-
-  # process column mapping
-  if (!is.null(column_names)) {
-    map <- column_names
-  } else {
-    map <- as.list(origin_cols)
-    names(map) <- map
-  }
-
-  if (factorized || imputed) {
-    `for`(s, names(convert_cols), `=`(map[map == s], convert_cols[s]))
-    `if`(imputed && flag, `=`(map, stats::setNames(c(map, flag_cols), c(names(map), flag_cols))))
-  }
-
-  list(data = data, covariates = covariates, map = map)
+  
+  list(data = data, nodes = nodes, column_names = column_names)
 }

--- a/R/process_missing.R
+++ b/R/process_missing.R
@@ -40,7 +40,7 @@ sl3_process_missing <- function(task, drop_missing_outcome = FALSE,
   # nodes to impute
   to_impute <- names(p_missing[(0 < p_missing) & (p_missing < max_p_missing)])
   if (length(to_impute) > 0) {
-    missing_indicators <- X[, lapply(.SD, function(x) as.numeric(is.na(x))),
+    missing_indicators <- X[, lapply(.SD, function(x) as.numeric(!is.na(x))),
       .SDcols = to_impute
     ]
     missing_names <- sprintf("delta_%s", to_impute)

--- a/tests/testthat/test-process_missing.R
+++ b/tests/testthat/test-process_missing.R
@@ -26,6 +26,7 @@ warnings <- capture_warnings({
     drop_missing_outcome = TRUE
   )
 })
+
 expect_equal(
   warnings,
   c(
@@ -39,7 +40,7 @@ expect_equal(
   task_drop_missing$nodes$covariates,
   c(
     "apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs",
-    "sexn", "apgar1_flag", "apgar5_flag", "meducyrs_flag", "parity_flag"
+    "sexn", "delta_apgar1", "delta_apgar5", "delta_parity", "delta_meducyrs"
   )
 )
 
@@ -55,3 +56,20 @@ expect_equal(
 )
 
 expect_equal(task_impute_covariates$nrow, nrow(cpp))
+
+# create data with missingness
+mtcars_with_missing <- data.table(copy(mtcars))
+mtcars_with_missing[sample(1:nrow(mtcars),10),cyl:=NA]
+
+# also add character column
+mtcars_with_missing[,gear:=as.character(gear)]
+
+# create a task specifing nodes
+covariates <- c("cyl","gear")
+suppressWarnings({
+task_from_nodes <- sl3_Task$new(mtcars_with_missing, nodes = list(outcome="mpg", covariates=covariates))
+})
+expected_covariates <- c(covariates, "delta_cyl")
+
+test_that("missing processing works when nodes is specified", 
+          expect_equal(task_from_nodes$nodes$covariates, expected_covariates))

--- a/tests/testthat/test-sl3_task.R
+++ b/tests/testthat/test-sl3_task.R
@@ -103,3 +103,6 @@ task_intfolds <- sl3_Task$new(mtcars,
 test_that("task$folds returns object with correct number of integer folds", {
   expect_equal(length(task_intfolds$folds), intfolds)
 })
+
+
+task_from_shared_data <- sl3_Task$new(data=task$.__enclos_env__$private$.shared_data, nodes=task$nodes)

--- a/tests/testthat/test-variable_type.R
+++ b/tests/testthat/test-variable_type.R
@@ -17,6 +17,7 @@ test_that(
   expect_equal(type_names, expected_variable_types)
 )
 
+variable_type(x=c(0,0,1,1,NA,0))
 
 # forcing outcome_type
 data(cpp)


### PR DESCRIPTION
Fixes several issues with `sl3_Task` creation and `process_data`:

* the covariate list wasn't being updated if `nodes` was specified
* if `data` was a `Shared_Data` object, the sl3_task referenced variables that didn't exist
* if a single column was subject to missingness, the flag ended up with a weird name
* Changed flag naming convention back to `delta_X` to match targeted learning convention
* Changed delta_X = 1 to indicate observed data, not censoring, to match targeted learning convention
* Used `data.table` `set` to modify data in place instead of using `=`
* Adds more tests to verify these fixes
 