### PR TITLE
Pass observation-level IDs in Lrnr_hal9001

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,8 +26,9 @@ Authors@R: c(
            role = "ctb")
   )
 Maintainer: Jeremy Coyle <jeremyrcoyle@gmail.com>
-Description: Modern implementation of the Super Learner prediction algorithm,
-    coupled with a general-purpose framework for machine learning via pipelines.
+Description: A modern implementation of the Super Learner prediction algorithm,
+    coupled with a general-purpose framework for composing arbitrary pipelines
+    for machine learning tasks.
 Depends: R (>= 2.14.0)
 Imports:
     data.table,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # sl3 1.3.8
 * Updates to variable importance functionality, including use of risk ratios.
+* Change `Lrnr_hal9001` and `Lrnr_glmnet` to respect observation-level IDs.
 
 # sl3 1.3.7
 * Sampling methods for Monte Carlo integration and related procedures.

--- a/R/Lrnr_glmnet.R
+++ b/R/Lrnr_glmnet.R
@@ -26,35 +26,41 @@
 #'   \item{\code{lambda=NULL}}{A vector of lambda values to compare}
 #'   \item{\code{type.measure="deviance"}}{The loss to use when selecting
 #'     lambda. Options documented in \code{\link[glmnet]{cv.glmnet}}.}
-#'   \item{\code{nfolds=10}}{Number of folds to use for internal
+#'   \item{\code{nfolds = 10}}{Number of folds to use for internal
 #'     cross-validation.}
-#'   \item{\code{alpha=1}}{The elastic net parameter. 0 is Ridge Regression, 1
-#'     is Lasso. Intermediate values are a combination. Documented in
+#'   \item{\code{alpha = 1}}{The elastic net parameter: \code{alpha = 0} is
+#'     Ridge (L2-penalized) regression, while \code{alpha = 1} specifies Lasso
+#'     (L1-penalized) regression. Values in the closed unit interval specify a
+#'     weighted combination of the two penalties. This is further documented in
 #'     \code{\link[glmnet]{glmnet}}.}
-#'   \item{\code{nlambda=100}}{The number of lambda values to compare. Comparing
+#'   \item{\code{nlambda=100}}{The number of lambda values to fit. Comparing
 #'     less values will speed up computation, but may decrease statistical
 #'     performance. Documented in \code{\link[glmnet]{cv.glmnet}}.}
-#'   \item{\code{use_min=TRUE}}{If TRUE, use lambda=cv_fit$lambda.min for prediction,
-#'     otherwise use lambda=cv_fit$lambda.1se.
-#'     the distinction is clarified in \code{\link[glmnet]{cv.glmnet}}.}
+#'   \item{\code{use_min=TRUE}}{If \code{TRUE}, use
+#'     \code{lambda = cv_fit$lambda.min} for prediction; otherwise, use
+#'     \code{lambda = cv_fit$lambda.1se}. The distinction between these is
+#'     clarified in \code{\link[glmnet]{cv.glmnet}}.}
 #'   \item{\code{...}}{Other parameters to be passed to
 #'     \code{\link[glmnet]{cv.glmnet}} and \code{\link[glmnet]{glmnet}}.}
 #' }
 #'
 #' @template common_parameters
-#
 Lrnr_glmnet <- R6Class(
   classname = "Lrnr_glmnet",
   inherit = Lrnr_base, portable = TRUE, class = TRUE,
   public = list(
-    initialize = function(lambda = NULL, type.measure = "deviance", nfolds = 10,
-                          alpha = 1, nlambda = 100, use_min = TRUE, ...) {
+    initialize = function(lambda = NULL, type.measure = "deviance",
+                          nfolds = 10, alpha = 1, nlambda = 100,
+                          use_min = TRUE, ...) {
       super$initialize(params = args_to_list(), ...)
     }
   ),
 
   private = list(
-    .properties = c("continuous", "binomial", "categorical", "weights"),
+    .properties = c(
+      "continuous", "binomial", "categorical",
+      "weights", "ids"
+    ),
 
     .train = function(task) {
       args <- self$params
@@ -85,9 +91,13 @@ Lrnr_glmnet <- R6Class(
         args$offset <- task$offset
       }
 
+      if (task$has_node("id")) {
+        args$foldid <- origami::folds2foldvec(task$folds)
+      }
+
       fit_object <- call_with_args(
         glmnet::cv.glmnet, args,
-        names(formals(glmnet::glmnet))
+        names(formals(glmnet::cv.glmnet))
       )
       fit_object$glmnet.fit$call <- NULL
       return(fit_object)
@@ -95,17 +105,22 @@ Lrnr_glmnet <- R6Class(
 
     .predict = function(task) {
       outcome_type <- private$.training_outcome_type
+
+      # set choice regularization penalty
       if (self$params$use_min) {
         lambda <- "lambda.min"
       } else {
         lambda <- "lambda.1se"
       }
+
+      # get predictions via S3 method
       predictions <- stats::predict(
         private$.fit_object,
         newx = as.matrix(task$X), type = "response",
         s = lambda
       )
 
+      # reformat predictions based on outcome type
       if (outcome_type$type == "categorical") {
         cat_names <- dimnames(predictions)[[2]]
         # predictions is a 3-dim matrix, convert to 2-dim matrix
@@ -116,6 +131,6 @@ Lrnr_glmnet <- R6Class(
       }
       return(predictions)
     },
-    .required_packages = c("glmnet")
+    .required_packages = c("glmnet", "origami")
   )
 )

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -94,7 +94,7 @@ Lrnr_hal9001 <- R6Class(
     }
   ),
   private = list(
-    .properties = c("continuous", "binomial"),
+    .properties = c("continuous", "binomial", "ids"),
 
     .train = function(task) {
       args <- self$params
@@ -115,6 +115,10 @@ Lrnr_hal9001 <- R6Class(
 
       if (task$has_node("offset")) {
         args$offset <- task$offset
+      }
+
+      if (task$has_node("id")) {
+        args$id <- task$id
       }
 
       fit_object <- call_with_args(hal9001::fit_hal, args)

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -5,10 +5,10 @@
 #'  interactions of covariates and fits Lasso regression to this (usually) very
 #'  wide matrix, recovering a nonparametric functional form that describes the
 #'  target prediction function as a composition of subset functions with finite
-#'  variation norm. This implementation uses the \code{hal9001} R package, which
-#'  provides both a custom implementation (based on the \code{origami} package)
-#'  of the CV-Lasso as well the standard call to \code{cv.glmnet} from the
-#'  \code{glmnet} package.
+#'  variation norm. This implementation uses \pkg{hal9001}, which provides both
+#'  a custom implementation (based on \pkg{origami}) of the cross-validated
+#'  lasso as well the standard call to \code{\link[glmnet]{cv.glmnet}} from the
+#'  \pkg{glmnet}.
 #'
 #' @docType class
 #' @importFrom R6 R6Class
@@ -47,17 +47,17 @@
 #'   \item{\code{reduce_basis=NULL}}{A \code{numeric} value bounded in the open
 #'    interval (0,1) indicating the minimum proportion of ones in a basis
 #'    function column needed for the basis function to be included in the
-#'    procedure to fit the Lasso. Any basis functions with a lower proportion of
-#'    1's than the specified cutoff will be removed. This argument defaults to
-#'    \code{NULL}, in which case all basis functions are used in the Lasso stage
-#'    of HAL.
+#'    procedure to fit the Lasso. Any basis functions with a lower proportion
+#'    of 1's than the specified cutoff will be removed. This argument defaults
+#'    to \code{NULL}, in which case all basis functions are used in the Lasso
+#'    stage of HAL.
 #'   }
 #'   \item{\code{return_lasso=TRUE}}{A \code{logical} indicating whether or not
 #'    to return the \code{\link[glmnet]{glmnet}} fit of the Lasso model.
 #'   }
 #'   \item{\code{return_x_basis=FALSE}}{A \code{logical} indicating whether or
-#'    not to return the matrix of (possibly reduced) basis functions used in the
-#'    HAL Lasso fit.
+#'    not to return the matrix of (possibly reduced) basis functions used in
+#'    the HAL Lasso fit.
 #'   }
 #'   \item{\code{basis_list=NULL}}{The full set of basis functions generated
 #'    from the input data (from \code{\link[hal9001]{enumerate_basis}}). The
@@ -65,10 +65,10 @@
 #'    the number of observations and d is the number of columns in the input.
 #'   }
 #'   \item{\code{cv_select=TRUE}}{A \code{logical} specifying whether the array
-#'    of values specified should be passed to \code{\link[glmnet]{cv.glmnet}} in
-#'    order to pick the optimal value (based on cross-validation) (when set to
-#'    \code{TRUE}) or to simply fit along the sequence of values (or a single
-#'    value) using \code{\link[glmnet]{glmnet}} (when set to \code{FALSE}).
+#'    of values specified should be passed to \code{\link[glmnet]{cv.glmnet}}
+#'    in order to pick the optimal value (based on cross-validation) (when set
+#'    to \code{TRUE}) or to fit along the sequence of values (or a single value
+#'    using \code{\link[glmnet]{glmnet}} (when set to \code{FALSE}).
 #'   }
 #'   \item{\code{...}}{Other parameters passed directly to
 #'    \code{\link[hal9001]{fit_hal}}. See its documentation for details.
@@ -94,7 +94,7 @@ Lrnr_hal9001 <- R6Class(
     }
   ),
   private = list(
-    .properties = c("continuous", "binomial", "ids"),
+    .properties = c("continuous", "binomial", "weights", "ids"),
 
     .train = function(task) {
       args <- self$params

--- a/man/Lrnr_glmnet.Rd
+++ b/man/Lrnr_glmnet.Rd
@@ -22,17 +22,20 @@ appropriate value of lambda.
 \item{\code{lambda=NULL}}{A vector of lambda values to compare}
 \item{\code{type.measure="deviance"}}{The loss to use when selecting
 lambda. Options documented in \code{\link[glmnet]{cv.glmnet}}.}
-\item{\code{nfolds=10}}{Number of folds to use for internal
+\item{\code{nfolds = 10}}{Number of folds to use for internal
 cross-validation.}
-\item{\code{alpha=1}}{The elastic net parameter. 0 is Ridge Regression, 1
-is Lasso. Intermediate values are a combination. Documented in
+\item{\code{alpha = 1}}{The elastic net parameter: \code{alpha = 0} is
+Ridge (L2-penalized) regression, while \code{alpha = 1} specifies Lasso
+(L1-penalized) regression. Values in the closed unit interval specify a
+weighted combination of the two penalties. This is further documented in
 \code{\link[glmnet]{glmnet}}.}
-\item{\code{nlambda=100}}{The number of lambda values to compare. Comparing
+\item{\code{nlambda=100}}{The number of lambda values to fit. Comparing
 less values will speed up computation, but may decrease statistical
 performance. Documented in \code{\link[glmnet]{cv.glmnet}}.}
-\item{\code{use_min=TRUE}}{If TRUE, use lambda=cv_fit$lambda.min for prediction,
-otherwise use lambda=cv_fit$lambda.1se.
-the distinction is clarified in \code{\link[glmnet]{cv.glmnet}}.}
+\item{\code{use_min=TRUE}}{If \code{TRUE}, use
+\code{lambda = cv_fit$lambda.min} for prediction; otherwise, use
+\code{lambda = cv_fit$lambda.1se}. The distinction between these is
+clarified in \code{\link[glmnet]{cv.glmnet}}.}
 \item{\code{...}}{Other parameters to be passed to
 \code{\link[glmnet]{cv.glmnet}} and \code{\link[glmnet]{glmnet}}.}
 }

--- a/man/Lrnr_hal9001.Rd
+++ b/man/Lrnr_hal9001.Rd
@@ -17,10 +17,10 @@ matrix consisting of basis functions corresponding to covariates and
 interactions of covariates and fits Lasso regression to this (usually) very
 wide matrix, recovering a nonparametric functional form that describes the
 target prediction function as a composition of subset functions with finite
-variation norm. This implementation uses the \code{hal9001} R package, which
-provides both a custom implementation (based on the \code{origami} package)
-of the CV-Lasso as well the standard call to \code{cv.glmnet} from the
-\code{glmnet} package.
+variation norm. This implementation uses \pkg{hal9001}, which provides both
+a custom implementation (based on \pkg{origami}) of the cross-validated
+lasso as well the standard call to \code{\link[glmnet]{cv.glmnet}} from the
+\pkg{glmnet}.
 }
 \section{Parameters}{
 
@@ -46,17 +46,17 @@ is the convention for V-fold cross-validation.
 \item{\code{reduce_basis=NULL}}{A \code{numeric} value bounded in the open
 interval (0,1) indicating the minimum proportion of ones in a basis
 function column needed for the basis function to be included in the
-procedure to fit the Lasso. Any basis functions with a lower proportion of
-1's than the specified cutoff will be removed. This argument defaults to
-\code{NULL}, in which case all basis functions are used in the Lasso stage
-of HAL.
+procedure to fit the Lasso. Any basis functions with a lower proportion
+of 1's than the specified cutoff will be removed. This argument defaults
+to \code{NULL}, in which case all basis functions are used in the Lasso
+stage of HAL.
 }
 \item{\code{return_lasso=TRUE}}{A \code{logical} indicating whether or not
 to return the \code{\link[glmnet]{glmnet}} fit of the Lasso model.
 }
 \item{\code{return_x_basis=FALSE}}{A \code{logical} indicating whether or
-not to return the matrix of (possibly reduced) basis functions used in the
-HAL Lasso fit.
+not to return the matrix of (possibly reduced) basis functions used in
+the HAL Lasso fit.
 }
 \item{\code{basis_list=NULL}}{The full set of basis functions generated
 from the input data (from \code{\link[hal9001]{enumerate_basis}}). The
@@ -64,10 +64,10 @@ dimensionality of this structure is roughly (n * 2^(d - 1)), where n is
 the number of observations and d is the number of columns in the input.
 }
 \item{\code{cv_select=TRUE}}{A \code{logical} specifying whether the array
-of values specified should be passed to \code{\link[glmnet]{cv.glmnet}} in
-order to pick the optimal value (based on cross-validation) (when set to
-\code{TRUE}) or to simply fit along the sequence of values (or a single
-value) using \code{\link[glmnet]{glmnet}} (when set to \code{FALSE}).
+of values specified should be passed to \code{\link[glmnet]{cv.glmnet}}
+in order to pick the optimal value (based on cross-validation) (when set
+to \code{TRUE}) or to fit along the sequence of values (or a single value
+using \code{\link[glmnet]{glmnet}} (when set to \code{FALSE}).
 }
 \item{\code{...}}{Other parameters passed directly to
 \code{\link[hal9001]{fit_hal}}. See its documentation for details.


### PR DESCRIPTION
Minor improvement / bugfix: pass observation-level IDs through `Lrnr_hal9001` to `hal9001::fit_hal`. It also takes the opportunity to implement minor fixes for `Lrnr_glmnet`, including passing in observation-level IDs via the `foldid` argument of `glmnet::cv.glmnet`.