### PR TITLE
save risk estimates in `Lrnr_sl`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,15 @@
 # sl3 1.4.3
-* Update `Lrnr_xgboost` to support prediction tasks consisting of one 
+* Update `Lrnr_xgboost` to support prediction tasks consisting of one
   observation (e.g., leave-one-out cross-validation).
-* Additional arguments for 'Keras' learners `Lrnr_lstm_keras` and 
-  `Lrnr_gru_keras` provide support for callback functions list and 2-layer 
-  networks. Default `callbacks` list provides early stopping criteria with 
+* Additional arguments for 'Keras' learners `Lrnr_lstm_keras` and
+  `Lrnr_gru_keras` provide support for callback functions list and 2-layer
+  networks. Default `callbacks` list provides early stopping criteria with
   respect to 'Keras' defaults and `patience` of 10 epochs.
+* Update `Lrnr_sl` by adding a new private slot `.cv_risk` to store the risk
+  estimates, using this to avoid unnecessary re-computation in the `print`
+  method (the `.cv_risk` slot is populated on the first `print` call, and only
+  ever re-printed thereafter).
+* Update documentation of `default_metalearner` to use native markdown tables.
 
 # sl3 1.4.2
 * Updates to variable importance functionality, including calculation of risk

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -86,7 +86,8 @@ Lrnr_base <- R6Class(
           colnames(delta_missing_data) <- delta_missing
           cols <- task$add_columns(data.table(delta_missing_data))
 
-          return(task$next_in_chain(covariates = ord_covs, column_names = cols))
+          return(task$next_in_chain(covariates = ord_covs,
+                                    column_names = cols))
         }
       } else {
         return(task)
@@ -172,7 +173,7 @@ Lrnr_base <- R6Class(
     assert_trained = function() {
       if (!self$is_trained) {
         stop(paste(
-          "Learner has not yet been train to data.",
+          "Learner has not yet been trained to data.",
           "Call learner$train(task) first."
         ))
       }
@@ -259,7 +260,10 @@ Lrnr_base <- R6Class(
       # for non-CV learners, do full predict no matter what, but warn about it
       # if fold_number is something else
       if (fold_number != "full") {
-        warning(self$name, " is not a cv-aware learner, so self$predict_fold reverts to self$predict")
+        warning(
+          self$name,
+          " is not cv-aware: self$predict_fold reverts to self$predict"
+        )
       }
       self$predict(task)
     },
@@ -267,7 +271,8 @@ Lrnr_base <- R6Class(
     reparameterize = function(new_params) {
       # modify learner parameters
       new_self <- self$clone()
-      new_self$.__enclos_env__$private$.params[names(new_params)] <- new_params[]
+      new_self$.__enclos_env__$private$.params[names(new_params)] <-
+        new_params[]
       return(new_self)
     },
 
@@ -288,7 +293,9 @@ Lrnr_base <- R6Class(
         new_self$.__enclos_env__$private$.params <- params_no_covars
       }
       if (!is.null(trained_sublearners)) {
-        new_fit_object <- new_self$.__enclos_env__$private$.train(new_task, trained_sublearners)
+        new_fit_object <-
+          new_self$.__enclos_env__$private$.train(new_task,
+                                                  trained_sublearners)
       } else {
         new_fit_object <- new_self$.__enclos_env__$private$.train(new_task)
       }
@@ -378,7 +385,7 @@ Lrnr_base <- R6Class(
     .train = function(task) {
       stop(paste(
         "Learner is meant to be abstract, you should instead use",
-        "specific learners. See listLearners()"
+        "specific learners. See sl3_list_learners()"
       ))
     },
 

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -86,8 +86,10 @@ Lrnr_base <- R6Class(
           colnames(delta_missing_data) <- delta_missing
           cols <- task$add_columns(data.table(delta_missing_data))
 
-          return(task$next_in_chain(covariates = ord_covs,
-                                    column_names = cols))
+          return(task$next_in_chain(
+            covariates = ord_covs,
+            column_names = cols
+          ))
         }
       } else {
         return(task)
@@ -294,8 +296,10 @@ Lrnr_base <- R6Class(
       }
       if (!is.null(trained_sublearners)) {
         new_fit_object <-
-          new_self$.__enclos_env__$private$.train(new_task,
-                                                  trained_sublearners)
+          new_self$.__enclos_env__$private$.train(
+            new_task,
+            trained_sublearners
+          )
       } else {
         new_fit_object <- new_self$.__enclos_env__$private$.train(new_task)
       }

--- a/R/Lrnr_sl.R
+++ b/R/Lrnr_sl.R
@@ -63,7 +63,6 @@ Lrnr_sl <- R6Class(
       lrn_names <- lapply(self$params$learners, function(obj) obj$name)
       print("SuperLearner:")
       str(lrn_names)
-      browser()
       if (self$is_trained) {
         fit_object <- private$.fit_object
         if (self$params$keep_extra) {

--- a/R/Lrnr_sl.R
+++ b/R/Lrnr_sl.R
@@ -72,8 +72,16 @@ Lrnr_sl <- R6Class(
           # compute MSE once and store, only compute if not available
           # (risk estimates are stored to avoid unnecessary re-calculation)
           if (is.null(private$.cv_risk)) {
-            loss_fun <- private$.params$metalearner$params$loss_function
-            private$.cv_risk <- self$cv_risk(loss_fun)
+            tryCatch({
+              # try using loss function based on outcome type
+              loss_fun <- private$.params$metalearner$params$loss_function
+              private$.cv_risk <- self$cv_risk(loss_fun)
+            }, error = function(c) {
+              # check training outcome type explicitly
+              metalearner <- default_metalearner(self$training_outcome_type)
+              loss_fun <- metalearner$params$loss_function
+              private$.cv_risk <- self$cv_risk(loss_fun)
+            })
           }
           print("Cross-validated risk:")
           print(private$.cv_risk)

--- a/R/Lrnr_sl.R
+++ b/R/Lrnr_sl.R
@@ -63,13 +63,21 @@ Lrnr_sl <- R6Class(
       lrn_names <- lapply(self$params$learners, function(obj) obj$name)
       print("SuperLearner:")
       str(lrn_names)
+      browser()
       if (self$is_trained) {
         fit_object <- private$.fit_object
         if (self$params$keep_extra) {
           # standard printing when all sub-parts of SL computation are stored
           print(fit_object$cv_meta_fit)
-          print("Cross-validated risk (MSE, squared error loss):")
-          print(self$cv_risk(loss_squared_error))
+
+          # compute MSE once and store, only compute if not available
+          # (risk estimates are stored to avoid unnecessary re-calculation)
+          if (is.null(private$.cv_risk)) {
+            loss_fun <- private$.params$metalearner$params$loss_function
+            private$.cv_risk <- self$cv_risk(loss_fun)
+          }
+          print("Cross-validated risk:")
+          print(private$.cv_risk)
         } else {
           # just print the remaining full fit object when keep_extra = FALSE
           print(fit_object$full_fit$params$learners[[2]])
@@ -82,7 +90,6 @@ Lrnr_sl <- R6Class(
       return(private$.fit_object$cv_meta_fit$fit_object)
     },
     cv_risk = function(loss_fun) {
-
       # get risks for cv learners (nested cv)
       cv_stack_fit <- self$fit_object$cv_fit
       stack_risks <- cv_stack_fit$cv_risk(loss_fun)
@@ -91,19 +98,19 @@ Lrnr_sl <- R6Class(
       if (!is.null(coefs)) {
         ordered_coefs <- coefs[match(stack_risks$learner, names(coefs))]
       } else {
-        # Metalearner did not provide coefficients.
+        # metalearner did not provide coefficients.
         ordered_coefs <- rep(NA, length(stack_risks$learner))
       }
       set(stack_risks, , "coefficients", ordered_coefs)
 
-      # Make sure that coefficients is the second column, even if the
+      # make sure that coefficients is the second column, even if the
       # metalearner did not provide coefficients.
       data.table::setcolorder(
         stack_risks,
         c(names(stack_risks)[1], "coefficients")
       )
 
-      # get risks for super learner (revere cv)
+      # get risks for super learner ("revere" CV)
       sl_risk <- cv_risk(self, loss_fun)
       set(sl_risk, , "learner", "SuperLearner")
 
@@ -154,7 +161,8 @@ Lrnr_sl <- R6Class(
 
       # fit meta-learner
       fit_object$cv_meta_task <- fit_object$cv_fit$chain(task)
-      fit_object$cv_meta_fit <- self$params$metalearner$train(fit_object$cv_meta_task)
+      fit_object$cv_meta_fit <-
+        self$params$metalearner$train(fit_object$cv_meta_task)
 
       # construct full fit pipeline
       full_stack_fit <- fit_object$cv_fit$fit_object$full_fit
@@ -164,7 +172,6 @@ Lrnr_sl <- R6Class(
         Pipeline, full_stack_fit,
         fit_object$cv_meta_fit
       )
-
       fit_object$full_fit <- full_fit
 
       new_object <- self$clone() # copy parameters, and whatever else
@@ -191,6 +198,9 @@ Lrnr_sl <- R6Class(
 
   private = list(
     .properties = c("wrapper", "cv"),
+
+    .cv_risk = NULL, # store risk estimates (avoid re-calculation on print)
+
     .train_sublearners = function(task) {
       # if we get a delayed task, evaluate it
       # TODO: this is a kludge:
@@ -218,7 +228,7 @@ Lrnr_sl <- R6Class(
       learner_stack <- do.call(Stack$new, list(learners))
       cv_stack <- Lrnr_cv$new(learner_stack, folds = folds, full_fit = TRUE)
 
-      # TODO: readd custom chain w/ better cv chain code
+      # TODO: read custom chain w/ better cv chain code
       # cv_stack$custom_chain(drop_offsets_chain)
 
       # fit stack on CV data
@@ -229,7 +239,7 @@ Lrnr_sl <- R6Class(
       cv_meta_fit <- delayed_learner_train(metalearner, cv_meta_task)
 
       # form full SL fit -- a pipeline with the stack fit to the full data,
-      # and the metalearner fit to the cv predictions
+      # and the metalearner fit to the CV predictions
       fit_object <- list(
         cv_fit = cv_fit, cv_meta_task = cv_meta_task,
         cv_meta_fit = cv_meta_fit

--- a/R/default_metalearner.R
+++ b/R/default_metalearner.R
@@ -16,17 +16,25 @@
 default_metalearner <- function(outcome_type) {
   outcome_type <- outcome_type$type
   if (outcome_type %in% c("constant", "binomial")) {
-    learner <- make_learner(Lrnr_solnp, metalearner_logistic_binomial,
-                            loss_squared_error)
+    learner <- make_learner(
+      Lrnr_solnp, metalearner_logistic_binomial,
+      loss_squared_error
+    )
   } else if (outcome_type == "categorical") {
-    learner <- make_learner(Lrnr_solnp, metalearner_linear_multinomial,
-                            loss_loglik_multinomial)
+    learner <- make_learner(
+      Lrnr_solnp, metalearner_linear_multinomial,
+      loss_loglik_multinomial
+    )
   } else if (outcome_type == "continuous") {
-    learner <- make_learner(Lrnr_solnp, metalearner_linear,
-                            loss_squared_error)
+    learner <- make_learner(
+      Lrnr_solnp, metalearner_linear,
+      loss_squared_error
+    )
   } else if (outcome_type == "multivariate") {
-    learner <- make_learner(Lrnr_solnp, metalearner_linear_multivariate,
-                            loss_squared_error_multivariate)
+    learner <- make_learner(
+      Lrnr_solnp, metalearner_linear_multivariate,
+      loss_squared_error_multivariate
+    )
   } else {
     stop(sprintf("Outcome type %s does not have a default metalearner."))
   }

--- a/R/default_metalearner.R
+++ b/R/default_metalearner.R
@@ -1,29 +1,34 @@
 #' Automatically Defined Metalearner
 #'
-#' A sensible metalearner based on \code{\link{Lrnr_solnp}} is chosen based on outcome type.
-#' This amounts to choosing an appropriate loss function and combination function.
-#' \tabular{rcc}{
-#' Outcome Type \tab Combination Function \tab Loss Function \cr
-#' binomial \tab metalearner_logistic_binomial \tab loss_squared_error \cr
-#' categorical \tab metalearner_linear_multinomial \tab loss_loglik_multinomial \cr
-#' continuous \tab metalearner_linear \tab loss_squared_error \cr
-#' multivariate \tab metalearner_linear_multivariate \tab loss_squared_error_multivariate \cr
-#' }
+#' A sensible metalearner based on \code{\link{Lrnr_solnp}} is chosen based on
+#' outcome type. This amounts to choosing an appropriate loss function and
+#' combination function.
+#'
+#' @details
+#'  | Outcome Type | Combination Function | Loss Function |
+#'  |:-------------|:---------------------| :-------------|
+#'  | binomial | metalearner_logistic_binomial | loss_squared_error |
+#'  | categorical | metalearner_linear_multinomial | loss_loglik_multinomial |
+#'  | continuous | metalearner_linear | loss_squared_error |
+#'  | multivariate | metalearner_linear_multivariate | loss_squared_error_multivariate |
 #'
 #' @param outcome_type a Variable_Type object
 default_metalearner <- function(outcome_type) {
   outcome_type <- outcome_type$type
   if (outcome_type %in% c("constant", "binomial")) {
-    learner <- make_learner(Lrnr_solnp, metalearner_logistic_binomial, loss_squared_error)
+    learner <- make_learner(Lrnr_solnp, metalearner_logistic_binomial,
+                            loss_squared_error)
   } else if (outcome_type == "categorical") {
-    learner <- make_learner(Lrnr_solnp, metalearner_linear_multinomial, loss_loglik_multinomial)
+    learner <- make_learner(Lrnr_solnp, metalearner_linear_multinomial,
+                            loss_loglik_multinomial)
   } else if (outcome_type == "continuous") {
-    learner <- make_learner(Lrnr_solnp, metalearner_linear, loss_squared_error)
+    learner <- make_learner(Lrnr_solnp, metalearner_linear,
+                            loss_squared_error)
   } else if (outcome_type == "multivariate") {
-    learner <- make_learner(Lrnr_solnp, metalearner_linear_multivariate, loss_squared_error_multivariate)
+    learner <- make_learner(Lrnr_solnp, metalearner_linear_multivariate,
+                            loss_squared_error_multivariate)
   } else {
-    stop(sprintf("Outcome type %s does not have a default metalearner. Please specify your own"))
+    stop(sprintf("Outcome type %s does not have a default metalearner."))
   }
-
   return(learner)
 }

--- a/man/default_metalearner.Rd
+++ b/man/default_metalearner.Rd
@@ -10,13 +10,16 @@ default_metalearner(outcome_type)
 \item{outcome_type}{a Variable_Type object}
 }
 \description{
-A sensible metalearner based on \code{\link{Lrnr_solnp}} is chosen based on outcome type.
-This amounts to choosing an appropriate loss function and combination function.
-\tabular{rcc}{
-Outcome Type \tab Combination Function \tab Loss Function \cr
-binomial \tab metalearner_logistic_binomial \tab loss_squared_error \cr
-categorical \tab metalearner_linear_multinomial \tab loss_loglik_multinomial \cr
-continuous \tab metalearner_linear \tab loss_squared_error \cr
-multivariate \tab metalearner_linear_multivariate \tab loss_squared_error_multivariate \cr
+A sensible metalearner based on \code{\link{Lrnr_solnp}} is chosen based on
+outcome type. This amounts to choosing an appropriate loss function and
+combination function.
+}
+\details{
+\tabular{lll}{
+   Outcome Type \tab Combination Function \tab Loss Function \cr
+   binomial \tab metalearner_logistic_binomial \tab loss_squared_error \cr
+   categorical \tab metalearner_linear_multinomial \tab loss_loglik_multinomial \cr
+   continuous \tab metalearner_linear \tab loss_squared_error \cr
+   multivariate \tab metalearner_linear_multivariate \tab loss_squared_error_multivariate \cr
 }
 }

--- a/tests/testthat/test-cv.R
+++ b/tests/testthat/test-cv.R
@@ -17,21 +17,25 @@ cv_glm <- Lrnr_cv$new(glm_learner, full_fit = TRUE)
 cv_glm_fit <- cv_glm$train(task)
 # debug_predict(cv_glm_fit)
 cv_glm_fit$predict()
-test_that("Lrnr_cv will use folds from task", expect_equal(task$folds, cv_glm_fit$fit_object$folds))
+test_that("Lrnr_cv will use folds from task", {
+  expect_equal(task$folds, cv_glm_fit$fit_object$folds)
+})
 
 folds <- make_folds(cpp_imputed, V = 5)
-task_2 <- sl3_Task$new(cpp_imputed, covariates = covars, outcome = outcome, folds = folds)
+task_2 <- sl3_Task$new(cpp_imputed, covariates = covars, outcome = outcome,
+                       folds = folds)
 test_that("task will accept custom folds", expect_length(task_2$folds, 5))
 
-test_that("we can generate predictions", expect_equal(length(cv_glm_fit$predict()), task_2$nrow))
+test_that("we can generate predictions", {
+  expect_equal(length(cv_glm_fit$predict()), task_2$nrow)
+})
 
 cv_glm_2 <- Lrnr_cv$new(glm_learner, folds = make_folds(cpp_imputed, V = 10))
 cv_glm_fit_2 <- cv_glm_2$train(task_2)
 cv_glm_fit_2$cv_risk(loss_squared_error)
-test_that("Lrnr_cv can override folds from task", expect_equal(
-  cv_glm_fit_2$params$folds,
-  cv_glm_fit_2$fit_object$folds
-))
+test_that("Lrnr_cv can override folds from task", {
+  expect_equal(cv_glm_fit_2$params$folds, cv_glm_fit_2$fit_object$folds)
+})
 
 glm_fit <- glm_learner$train(task)
 test_that(
@@ -76,7 +80,8 @@ folds <- origami::make_folds(trend_all$data,
 lrnr_glm <- make_learner(Lrnr_glm)
 lrnr_mean <- make_learner(Lrnr_mean)
 sl <- make_learner(Lrnr_sl, list(lrnr_glm, lrnr_mean))
-task <- sl3_Task$new(trend_all, covariates = "data", outcome = "data", folds = folds)
+task <- sl3_Task$new(trend_all, covariates = "data",
+                     outcome = "data", folds = folds)
 fit <- sl$train(task)
 fit$predict_fold(task, "validation")
 cv_risk_table <- fit$cv_risk(loss_squared_error)

--- a/tests/testthat/test-sl.R
+++ b/tests/testthat/test-sl.R
@@ -7,10 +7,13 @@ library(origami)
 library(SuperLearner)
 
 data(cpp_imputed)
-covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs", "sexn")
+covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs",
+            "sexn")
 outcome <- "haz"
-task <- sl3_Task$new(data.table::copy(cpp_imputed), covariates = covars, outcome = outcome)
-task2 <- sl3_Task$new(data.table::copy(cpp_imputed), covariates = covars, outcome = outcome)
+task <- sl3_Task$new(data.table::copy(cpp_imputed),
+                     covariates = covars, outcome = outcome)
+task2 <- sl3_Task$new(data.table::copy(cpp_imputed),
+                      covariates = covars, outcome = outcome)
 
 glm_learner <- Lrnr_glm$new()
 glmnet_learner <- Lrnr_pkg_SuperLearner$new("SL.glmnet")
@@ -19,18 +22,26 @@ learners <- list(glm_learner, glmnet_learner, subset_apgar)
 sl1 <- make_learner(Lrnr_sl, learners, glm_learner)
 
 sl1_fit <- sl1$train(task)
-test_that("Coefficients can extracted from sl fits", expect_true(!is.null(coef(sl1_fit))))
+test_that("Coefficients can extracted from sl fits", {
+  expect_true(!is.null(coef(sl1_fit)))
+})
 glm_fit <- sl1_fit$learner_fits$Lrnr_glm_TRUE
-test_that("Library fits can extracted from sl fits", expect_true(inherits(glm_fit, "Lrnr_glm")))
+test_that("Library fits can extracted from sl fits", {
+  expect_true(inherits(glm_fit, "Lrnr_glm"))
+})
 
 
 sl1_risk <- sl1_fit$cv_risk(loss_squared_error)
 
 expected_learners <- c(
-  "Lrnr_glm_TRUE", "Lrnr_pkg_SuperLearner_SL.glmnet", "Lrnr_subset_covariates_c(\"apgar1\", \"apgar5\")_apgar1",
+  "Lrnr_glm_TRUE", "Lrnr_pkg_SuperLearner_SL.glmnet",
+  "Lrnr_subset_covariates_c(\"apgar1\", \"apgar5\")_apgar1",
   "Lrnr_subset_covariates_c(\"apgar1\", \"apgar5\")_apgar5"
 )
-test_that("sl1_fit is based on the right learners", expect_equal(sl1_fit$fit_object$cv_meta_task$nodes$covariates, expected_learners))
+test_that("sl1_fit is based on the right learners", {
+  expect_equal(sl1_fit$fit_object$cv_meta_task$nodes$covariates,
+               expected_learners)
+})
 
 stack <- make_learner(Stack, learners)
 sl2 <- make_learner(Lrnr_sl, stack, glm_learner)
@@ -38,26 +49,36 @@ sl2 <- make_learner(Lrnr_sl, stack, glm_learner)
 sl2_fit <- sl2$train(task)
 sl2_risk <- sl2_fit$cv_risk(loss_squared_error)
 
-test_that("Lrnr_sl can accept a pre-made stack", expect_equal(sl1_risk$mean_risk, sl2_risk$mean_risk, tolerance = 1e-2))
+test_that("Lrnr_sl can accept a pre-made stack", {
+  expect_equal(sl1_risk$mean_risk, sl2_risk$mean_risk, tolerance = 1e-2)
+})
 
-sl_nnls <- Lrnr_sl$new(learners = list(glm_learner, glmnet_learner), metalearner = sl3::Lrnr_nnls$new())
+sl_nnls <- Lrnr_sl$new(learners = list(glm_learner, glmnet_learner),
+                       metalearner = sl3::Lrnr_nnls$new())
 sl_nnls_fit <- sl_nnls$train(task)
 
-sl1_small <- Lrnr_sl$new(learners = list(glm_learner, glmnet_learner, subset_apgar), metalearner = glm_learner, keep_extra = FALSE)
+sl1_small <- Lrnr_sl$new(learners = list(glm_learner, glmnet_learner,
+                                         subset_apgar),
+                         metalearner = glm_learner, keep_extra = FALSE)
 sl1_small_fit <- sl1_small$train(task)
 expect_lt(length(sl1_small_fit$fit_object), length(sl1_fit$fit_object))
 preds <- sl1_small_fit$predict(task)
 preds_fold <- sl1_small_fit$predict_fold(task, "full")
-test_that("predict_fold(task,'full') works if keep_extra=FALSE", expect_equal(preds, preds_fold))
+test_that("predict_fold(task,'full') works if keep_extra=FALSE", {
+  expect_equal(preds, preds_fold)
+})
 
 # sl of a pipeline from https://github.com/tlverse/sl3/issues/81
 data(cpp)
 cpp <- cpp[!is.na(cpp[, "haz"]), ]
-covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs", "sexn")
+covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs",
+            "sexn")
 cpp[is.na(cpp)] <- 0
 outcome <- "haz"
 task <- sl3_Task$new(cpp, covariates = covars, outcome = outcome)
-make_inter <- Lrnr_define_interactions$new(interactions = list(c("apgar1", "parity"), c("apgar5", "parity")))
+make_inter <- Lrnr_define_interactions$new(
+  interactions = list(c("apgar1", "parity"), c("apgar5", "parity"))
+)
 
 glm_learner <- Lrnr_glm$new()
 glmnet_learner <- Lrnr_glmnet$new(nlambda = 5)


### PR DESCRIPTION
A small PR to
* Update `Lrnr_sl` by adding a new private slot `.cv_risk` to store the risk estimates, using this to avoid unnecessary re-computation in the `print` method (the `.cv_risk` slot is populated on the first `print` call, and only ever re-printed thereafter).
* Update documentation of `default_metalearner` to use native markdown tables.