### PR TITLE
Fixes categorical learners and prediction

### DIFF
--- a/R/Lrnr_bartMachine.R
+++ b/R/Lrnr_bartMachine.R
@@ -70,11 +70,15 @@ Lrnr_bartMachine <- R6Class(
   ),
 
   private = list(
-    .properties = c("continuous", "binomial", "categorical"),
+    .properties = c("continuous", "binomial"),
 
     .train = function(task) {
       args <- self$params
       outcome_type <- self$get_outcome_type(task)
+      
+      if (outcome_type$type == "categorical") {
+        stop("Unsupported outcome type for Lrnr_bartMachine")
+      }
 
       # specify data
       args$X <- as.data.frame(task$X)

--- a/R/Lrnr_dbarts.R
+++ b/R/Lrnr_dbarts.R
@@ -114,11 +114,15 @@ Lrnr_dbarts <- R6Class(
   ),
 
   private = list(
-    .properties = c("continuous", "binomial", "categorical", "weights"),
+    .properties = c("continuous", "binomial", "weights"),
 
     .train = function(task) {
       args <- self$params
       outcome_type <- self$get_outcome_type(task)
+      
+      if (outcome_type$type == "categorical") {
+        stop("Unsupported outcome type for Lrnr_dbarts")
+      }
 
       # specify data
       args$x.train <- as.data.frame(task$X)

--- a/R/Lrnr_gam.R
+++ b/R/Lrnr_gam.R
@@ -58,7 +58,7 @@ Lrnr_gam <- R6Class(
   ),
 
   private = list(
-    .properties = c("continuous", "binomial", "categorical"),
+    .properties = c("continuous", "binomial"),
 
     .train = function(task) {
       # load args

--- a/R/Lrnr_independent_binomial.R
+++ b/R/Lrnr_independent_binomial.R
@@ -93,6 +93,7 @@ Lrnr_independent_binomial <- R6Class(
       # compute other categories relative to baseline
       predictions <- baseline * transformed
       predictions <- cbind(baseline, predictions)
+      colnames(predictions) <- levels(task$Y)
       predictions <- pack_predictions(predictions)
       return(predictions)
     },

--- a/tests/testthat/test-bartMachine.R
+++ b/tests/testthat/test-bartMachine.R
@@ -1,0 +1,3 @@
+context("test-bartMachine.R -- Lrnr_bartMachine")
+
+library(bartMachine)

--- a/tests/testthat/test-bartMachine.R
+++ b/tests/testthat/test-bartMachine.R
@@ -1,3 +1,30 @@
 context("test-bartMachine.R -- Lrnr_bartMachine")
 
 library(bartMachine)
+
+data(cpp_imputed)
+covars <- c(
+  "apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs",
+  "sexn"
+)
+outcome <- "haz"
+task <- sl3_Task$new(cpp_imputed,
+                     covariates = covars,
+                     outcome = outcome
+)
+
+test_that("Lrnr_bartMachine produces results matching those of bartMachine::bartMachine", {
+  # get predictions from Lrnr_* wrapper
+  lrnr_bartMachine <- make_learner(Lrnr_bartMachine, seed = 123)
+  fit <- lrnr_bartMachine$train(task)
+  preds <- fit$predict(task)
+  
+  # get predictions from classic implementation
+  fit_classic <- bartMachine::bartMachine(
+    X = data.frame(task$X), y = task$Y, num_trees = 50, 
+    num_burn_in = 250, seed = 123)
+  preds_classic <- predict(fit_classic, new_data = task$X)
+  
+  # check equality of predictions
+  expect_equal(preds, as.numeric(preds_classic))
+})

--- a/tests/testthat/test-dbarts.R
+++ b/tests/testthat/test-dbarts.R
@@ -1,4 +1,4 @@
-context("test barts: bartMachine and dbart")
+context("test-dbarts.R -- Lrnr_dbarts")
 
 library(dbarts)
 

--- a/tests/testthat/test-dbarts.R
+++ b/tests/testthat/test-dbarts.R
@@ -39,6 +39,26 @@ outcome <- names(y)
 data <- cbind.data.frame(y, x)
 task <- sl3_Task$new(data, covariates = covars, outcome = outcome)
 
+test_that("Lrnr_dbarts produces results matching those of dbarts::barts", {
+  # get predictions from Lrnr_* wrapper
+  set.seed(123)
+  lrnr_dbarts <- make_learner(Lrnr_dbarts)
+  fit <- lrnr_dbarts$train(task)
+  preds <- fit$predict(task)
+  
+  # get predictions from classic implementation
+  set.seed(123)
+  fit_classic <- dbarts::bart(
+    x.train = data.frame(task$X), y.train = task$Y, keeptrees = TRUE, ndpost = 500
+  )
+  
+  preds_classic <- rowMeans(t(predict(fit_classic, newdata = task$X)))
+  
+  # check equality of predictions
+  expect_equal(preds, as.numeric(preds_classic))
+})
+
+
 test_that("Lrnr_dbarts with continuous outcome works", {
   dbart_learner <- Lrnr_dbarts$new(ndpost = 200)
   dbart_fit <- dbart_learner$train(task)

--- a/tests/testthat/test-independent_binomial.R
+++ b/tests/testthat/test-independent_binomial.R
@@ -1,6 +1,6 @@
 context("test-independent_binomial.R -- Lrnr_independent_binomial")
 
-library(tidyverse)
+library(dplyr)
 
 data(cpp)
 

--- a/tests/testthat/test-independent_binomial.R
+++ b/tests/testthat/test-independent_binomial.R
@@ -1,0 +1,25 @@
+context("test-independent_binomial.R -- Lrnr_independent_binomial")
+
+library(tidyverse)
+
+data(cpp)
+
+cpp <- cpp %>%
+  select(c(bmi, agedays, feeding)) %>%
+  mutate(feeding = as.factor(feeding)) %>%
+  na.omit
+
+task <- make_sl3_Task(cpp, covariates = c("agedays", "bmi"), outcome = "feeding")
+
+test_that("Lrnr_independent_binomial produces predictions with retained factor levels", {
+  # get predictions from Lrnr_* wrapper
+  lrnr_indbinomial <- make_learner(Lrnr_independent_binomial)
+  fit <- lrnr_indbinomial$train(task)
+  preds <- fit$predict(task)
+  
+  original_names <- levels(cpp$feeding)
+  predicted_names <- names(preds[[1]][[1]])
+  
+  # check equality of predictions
+  expect_equal(original_names, predicted_names)
+})

--- a/tests/testthat/test-multinomial_learners.R
+++ b/tests/testthat/test-multinomial_learners.R
@@ -85,3 +85,15 @@ test_that("Lrnr_sl multinomial integration test", {
   preds <- sl_fit$base_predict()
   sl_fit$cv_risk(loss_loglik_multinomial)
 })
+
+test_that("Lrnr_sl produces predictions with retained factor levels", {
+  # get predictions from Lrnr_* wrapper
+  sl_fit <- mn_sl$train(task)
+  preds <- sl_fit$base_predict()
+  
+  original_names <- levels(data$A)
+  predicted_names <- names(preds[[1]][[1]])
+  
+  # check equality of predictions
+  expect_equal(original_names, predicted_names)
+})


### PR DESCRIPTION
This pull request focuses on categorical learners, specifically:

1. Removes categorical outcome possibility for bartMachine per the pdf documentation. Adds a stop to prevent this learner from executing when a categorical outcome is present.

2. Removes categorical outcome possibility for dbarts per the pdf documentation. Adds a stop to prevent this learner from executing when a categorical outcome is present.

3. Removes categorical outcome possibility for gam as this has not been implemented yet.

4. Reclaims factor names from "baseline" to the original factor name for the Lrnr_independent_binomial learner.

```{r}
library(tidyverse)

data(cpp)

cpp <- cpp %>%
  select(c(bmi, agedays, feeding)) %>%
  mutate(feeding = as.factor(feeding)) %>%
  na.omit

task <- make_sl3_Task(cpp, covariates = c("agedays", "bmi"), outcome = "feeding")

lrnr_indbinomial <- make_learner(Lrnr_independent_binomial)

stack_learners <- make_learner(
  Stack,
  lrnr_indbinomial
)

sl <- sl3::Lrnr_sl$new(learners = stack_learners)
stack_fit <- sl$train(task)

predictions <- stack_fit$predict()
names(predictions[[1]][[1]])
```

__We expect:__  Exclusively breast fed, Exclusively formula fed, Mixture breast/formula fed, Unknown 
__What we get:__ Baseline, Exclusively formula fed, Mixture breast/formula fed, Unknown 


4. Changed the testing file structure for "barts" to break down into both "dbarts" and "bartMachine" separately (as they are different learners).

5. Adds tests for dbart and bartMachine

6. Adds a Lrnr_independent_binomial test file and also adds testing for factor names to be recovered after prediction with Lrnr_independent_binomial