### PR TITLE
`README` details on CV and `future`

### DIFF
--- a/R/variable_type.R
+++ b/R/variable_type.R
@@ -1,7 +1,6 @@
 #' @rdname variable_type
 #'
 #' @export
-#
 Variable_Type <- R6Class(
   classname = "Variable_Type",
   portable = TRUE,
@@ -11,7 +10,7 @@ Variable_Type <- R6Class(
                           pcontinuous = getOption("sl3.pcontinuous")) {
       if (is.null(type)) {
         if (is.null(x)) {
-          stop("type not specified, and no x from which to infer it")
+          stop("type not specified, and no x from which to infer it.")
         }
         nunique <- length(na.exclude(unique(x)))
         if (!is.null(ncol(x))) {
@@ -20,7 +19,8 @@ Variable_Type <- R6Class(
           type <- "constant"
         } else if (nunique == 2) {
           type <- "binomial"
-        } else if ((is.factor(x)) || (((nunique / length(x)) < pcontinuous) && (nunique < 20))) {
+        } else if ((is.factor(x)) || (((nunique / length(x)) < pcontinuous) &&
+                                      (nunique < 20))) {
           type <- "categorical"
         } else {
           type <- "continuous"
@@ -119,17 +119,17 @@ Variable_Type <- R6Class(
   )
 )
 
-#' Specify variable type
+#' Specify Variable Type
 #'
-#' @param type A type name.
+#' @param type A type name. Valid choices include "binomial", "categorical",
+#'  "continuous", and "multivariate". When not specified, this is inferred.
 #' @param levels Valid levels for discrete types.
-#' @param bounds Bounds for continous variables.
+#' @param bounds Bounds for continuous variables.
 #' @param x Data to use for inferring type if not specified.
-#' @param pcontinuous If \code{type} above is inferred, the proportion of unique
-#'  observations above which variable is continuous
+#' @param pcontinuous If \code{type} above is inferred, the proportion of
+#'  unique observations above which the variable is considered continuous.
 #'
 #' @export
-#
 variable_type <- function(type = NULL, levels = NULL, bounds = NULL, x = NULL,
                           pcontinuous = getOption("sl3.pcontinuous")) {
   return(Variable_Type$new(

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,6 +53,10 @@ two fashions:
    regression_ [@breiman1996stacked] and _stacked generalization_
    [@wolpert1992stacked].
 
+Looking for long-form documentation or a walkthrough of the `sl3` package? Don't
+worry! Just take a look at [the chapter in our
+book](ihttps://tlverse.org/tlverse-handbook/sl3.html).
+
 ---
 
 ## Installation
@@ -117,7 +121,11 @@ cpp <- cpp %>%
 # use covariates of intest and the outcome to build a task object
 covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs",
             "sexn")
-task <- sl3_Task$new(cpp, covariates = covars, outcome = "haz")
+task <- sl3_Task$new(
+  data = cpp,
+  covariates = covars,
+  outcome = "haz"
+)
 
 # set up screeners and learners via built-in functions and pipelines
 slscreener <- Lrnr_pkg_SuperLearner_screener$new("screen.glmnet")
@@ -131,6 +139,56 @@ stack_fit <- learner_stack$train(task)
 preds <- stack_fit$predict()
 head(preds)
 ```
+
+### Parallelization with `future`s
+
+While it's straightforward to fit a stack of learners (as above), it's easy to
+take advantage of `sl3`'s built-in parallelization support too. To do this,
+you can simply choose a `plan()` from the [`future`
+ecosystem](https://CRAN.R-project.org/package=future).
+
+```{r sl3-parallel-example, eval=FALSE, message=FALSE, warning=FALSE}
+# let's load the future package and set 4 cores for parallelization
+library(future)
+plan(multisession, workers = 4L)
+
+# now, let's re-train our Stack in parallel
+stack_fit <- learner_stack$train(task)
+preds <- stack_fit$predict()
+```
+
+### Controlling the number of CV folds
+
+In the above examples, we fit stacks of learners, but didn't create a Super
+Learner ensemble, which uses cross-validation (CV) to build the ensemble model.
+For the sake of computational expedience, we may be interested in lowering the
+number of CV folds (from 10).  Let's take a look at how to do both below.
+
+```{r sl3-folds-example, eval=FALSE, message=FALSE, warning=FALSE}
+# first, let's instantiate some more learners and create a Super Learner
+mean_learner <- Lrnr_mean$new()
+rf_learner <- Lrnr_ranger$new()
+sl <- Lrnr_sl$new(mean_learner, glm_learner, rf_learner)
+
+# CV folds are controlled in the sl3_Task object; we can lower the number of
+# folds simply by specifying this in creating the Task
+task <- sl3_Task$new(
+  data = cpp,
+  covariates = covars,
+  outcome = "haz",
+  folds = 5L
+)
+
+# now, let's fit the Super Learner with just 5-fold CV, then get predictions
+sl_fit <- sl$train(task)
+sl_preds <- sl_fit$predict()
+```
+
+The `folds` argument to `sl3_Task` supports both integers (for V-fold CV) and
+all of the CV schemes supported in the [`origami`
+package](https://CRAN.R-project.org/package=origami). To see the full list,
+query `?fold_funs` from within `R` or take a look at [`origami`'s online
+documentation](https://tlverse.org/origami/reference/).
 
 ---
 
@@ -204,7 +262,7 @@ submitting a pull request.
 
 After using the `sl3` R package, please cite the following:
 
-        @manual{coyle2021sl3,
+        @software{coyle2021sl3-rpkg,
           author = {Coyle, Jeremy R and Hejazi, Nima S and Malenica, Ivana and
             Sofrygin, Oleg},
           title = {{sl3}: Modern Pipelines for Machine Learning and {Super

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,9 +53,9 @@ two fashions:
    regression_ [@breiman1996stacked] and _stacked generalization_
    [@wolpert1992stacked].
 
-Looking for long-form documentation or a walkthrough of the `sl3` package? Don't
-worry! Just take a look at [the chapter in our
-book](ihttps://tlverse.org/tlverse-handbook/sl3.html).
+Looking for long-form documentation or a walkthrough of the `sl3` package?
+Don't worry! Just take a look at [the chapter in our
+book](https://tlverse.org/tlverse-handbook/sl3.html).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ performs ensemble learning in one of two fashions:
 
 Looking for long-form documentation or a walkthrough of the `sl3`
 package? Don’t worry\! Just take a look at [the chapter in our
-book](ihttps://tlverse.org/tlverse-handbook/sl3.html).
+book](https://tlverse.org/tlverse-handbook/sl3.html).
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ performs ensemble learning in one of two fashions:
     also been referred to as *stacked regression* (Breiman 1996) and
     *stacked generalization* (Wolpert 1992).
 
+Looking for long-form documentation or a walkthrough of the `sl3`
+package? Don’t worry\! Just take a look at [the chapter in our
+book](ihttps://tlverse.org/tlverse-handbook/sl3.html).
+
 -----
 
 ## Installation
@@ -113,7 +117,11 @@ cpp <- cpp %>%
 # use covariates of intest and the outcome to build a task object
 covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs",
             "sexn")
-task <- sl3_Task$new(cpp, covariates = covars, outcome = "haz")
+task <- sl3_Task$new(
+  data = cpp,
+  covariates = covars,
+  outcome = "haz"
+)
 
 # set up screeners and learners via built-in functions and pipelines
 slscreener <- Lrnr_pkg_SuperLearner_screener$new("screen.glmnet")
@@ -141,6 +149,57 @@ head(preds)
 #> 5:                                                            0.25870995
 #> 6:                                                            0.05600958
 ```
+
+### Parallelization with `future`s
+
+While it’s straightforward to fit a stack of learners (as above), it’s
+easy to take advantage of `sl3`’s built-in parallelization support too.
+To do this, you can simply choose a `plan()` from the [`future`
+ecosystem](https://CRAN.R-project.org/package=future).
+
+``` r
+# let's load the future package and set 4 cores for parallelization
+library(future)
+plan(multisession, workers = 4L)
+
+# now, let's re-train our Stack in parallel
+stack_fit <- learner_stack$train(task)
+preds <- stack_fit$predict()
+```
+
+### Controlling the number of CV folds
+
+In the above examples, we fit stacks of learners, but didn’t create a
+Super Learner ensemble, which uses cross-validation (CV) to build the
+ensemble model. For the sake of computational expedience, we may be
+interested in lowering the number of CV folds (from 10). Let’s take a
+look at how to do both below.
+
+``` r
+# first, let's instantiate some more learners and create a Super Learner
+mean_learner <- Lrnr_mean$new()
+rf_learner <- Lrnr_ranger$new()
+sl <- Lrnr_sl$new(mean_learner, glm_learner, rf_learner)
+
+# CV folds are controlled in the sl3_Task object; we can lower the number of
+# folds simply by specifying this in creating the Task
+task <- sl3_Task$new(
+  data = cpp,
+  covariates = covars,
+  outcome = "haz",
+  folds = 5L
+)
+
+# now, let's fit the Super Learner with just 5-fold CV, then get predictions
+sl_fit <- sl$train(task)
+sl_preds <- sl_fit$predict()
+```
+
+The `folds` argument to `sl3_Task` supports both integers (for V-fold
+CV) and all of the CV schemes supported in the [`origami`
+package](https://CRAN.R-project.org/package=origami). To see the full
+list, query `?fold_funs` from within `R` or take a look at [`origami`’s
+online documentation](https://tlverse.org/origami/reference/).
 
 -----
 
@@ -6007,7 +6066,7 @@ prior to submitting a pull request.
 After using the `sl3` R package, please cite the following:
 
 ``` 
-    @manual{coyle2021sl3,
+ @software{coyle2021sl3-rpkg,
       author = {Coyle, Jeremy R and Hejazi, Nima S and Malenica, Ivana and
         Sofrygin, Oleg},
       title = {{sl3}: Modern Pipelines for Machine Learning and {Super
@@ -6036,7 +6095,7 @@ See file `LICENSE` for details.
 
 ## References
 
-<div id="refs" class="references hanging-indent">
+<div id="refs" class="references">
 
 <div id="ref-breiman1996stacked">
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -5,9 +5,10 @@ note <- sprintf("R package version %s", meta$Version)
 
 bibentry(bibtype = "Manual",
          title = "{sl3}: Pipelines for Machine Learning and {Super Learning}",
-         author = c(person("Jeremy", "Coyle", "R"),
-                    person("Nima", "Hejazi", "S"),
+         author = c(person("Jeremy", "Coyle"),
+                    person("Nima", "Hejazi"),
                     person("Ivana", "Malenica"),
+                    person("Rachael", "Phillips"),
                     person("Oleg", "Sofrygin")),
          year = year,
          note = note,

--- a/man/variable_type.Rd
+++ b/man/variable_type.Rd
@@ -3,23 +3,24 @@
 \name{Variable_Type}
 \alias{Variable_Type}
 \alias{variable_type}
-\title{Specify variable type}
+\title{Specify Variable Type}
 \usage{
 variable_type(type = NULL, levels = NULL, bounds = NULL, x = NULL,
   pcontinuous = getOption("sl3.pcontinuous"))
 }
 \arguments{
-\item{type}{A type name.}
+\item{type}{A type name. Valid choices include "binomial", "categorical",
+"continuous", and "multivariate". When not specified, this is inferred.}
 
 \item{levels}{Valid levels for discrete types.}
 
-\item{bounds}{Bounds for continous variables.}
+\item{bounds}{Bounds for continuous variables.}
 
 \item{x}{Data to use for inferring type if not specified.}
 
-\item{pcontinuous}{If \code{type} above is inferred, the proportion of unique
-observations above which variable is continuous}
+\item{pcontinuous}{If \code{type} above is inferred, the proportion of
+unique observations above which the variable is considered continuous.}
 }
 \description{
-Specify variable type
+Specify Variable Type
 }


### PR DESCRIPTION
This is a small PR meant to address #322, adding details on using `future::plan()` for parallelization and setting the number of CV folds in `sl3_Task` objects in the `README`. It also adds pointers to the `sl3` book chapter and the `origami` `pkgdown` website.