### PR TITLE
Fix warning from xgboost v1.3.0+

### DIFF
--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -1,10 +1,10 @@
 #' xgboost: eXtreme Gradient Boosting
 #'
-#' This learner provides fitting procedures for \code{xgboost} models, using the
-#' \code{xgboost} package, using the \code{\link[xgboost]{xgb.train}} function.
-#' Such models are classification and regression trees with extreme gradient
+#' This learner provides fitting procedures for \code{xgboost} models, using
+#' the \pkg{xgboost} package, using \code{\link[xgboost]{xgb.train}}. Such
+#' models are classification and regression trees with extreme gradient
 #' boosting. For details on the fitting procedure, consult the documentation of
-#' the \code{xgboost} package.
+#' the \pkg{xgboost}.
 #'
 #' @docType class
 #'
@@ -99,6 +99,7 @@ Lrnr_xgboost <- R6Class(
       if (is.null(args$objective)) {
         if (outcome_type$type == "binomial") {
           args$objective <- "binary:logistic"
+          args$eval_metric <- "logloss"
         } else if (outcome_type$type == "quasibinomial") {
           args$objective <- "reg:logistic"
         } else if (outcome_type$type == "categorical") {


### PR DESCRIPTION
When training on a task with a binary outcome, `Lrnr_xgboost` emits the following warning:
```
WARNING: amalgamation/../src/learner.cc:1061: Starting in XGBoost 1.3.0, the default evaluation metric used with the objective 'binary:logistic' was changed from 'error' to 'logloss'. Explicitly set eval_metric if you'd like to restore the old behavior.
```
To fix this, `Lrnr_xgboost` explicitly sets `args$eval_metric <- "logloss"` when the outcome family is detected to be binomial, which suppresses this warning without altering performance.