### PR TITLE
Fix xgboost v1.3.0+ warning...categorical outcomes

### DIFF
--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -105,6 +105,7 @@ Lrnr_xgboost <- R6Class(
         } else if (outcome_type$type == "categorical") {
           args$objective <- "multi:softprob"
           args$num_class <- length(outcome_type$levels)
+          args$eval_metric <- "mlogloss"
         }
       }
       fit_object <- call_with_args(xgboost::xgb.train, args, keep_all = TRUE)


### PR DESCRIPTION
Basically the same as #329 but for categorical outcomes. When training on a task with a categorical outcome, `Lrnr_xgboost` emits the following warning:
```
#> WARNING: amalgamation/../src/learner.cc:1061: Starting in XGBoost 1.3.0, the default evaluation metric used with the objective 'multi:softprob' was changed from 'merror' to 'mlogloss'. Explicitly set eval_metric if you'd like to restore the old behavior.
```
To fix this, `Lrnr_xgboost` explicitly sets `args$eval_metric <- "mlogloss"` when the outcome family is detected to be categorical, which suppresses this warning without altering performance.