### PR TITLE
Fix `pooled_hazard_task` bug

### DIFF
--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -121,7 +121,7 @@ Lrnr_hal9001 <- R6Class(
         args$id <- task$id
       }
 
-      fit_object <- call_with_args(hal9001::fit_hal, args)
+      fit_object <- call_with_args(hal9001::fit_hal, args, keep_all = TRUE)
       return(fit_object)
     },
     .predict = function(task = NULL) {

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -127,7 +127,7 @@ Lrnr_hal9001 <- R6Class(
       }
       if(!is.null(self$params$formula)) {
         args$data <- task$data
-        formula <- call_with_args(hal9001::formula_hal, args, keep_all = TRUE)
+        formula <- call_with_args(hal9001::formula_hal, args, ignore = c("X", "Y"))
         fit_object <- hal9001::fit_hal_formula(formula)
       } else {
         fit_object <- call_with_args(hal9001::fit_hal, args, keep_all = TRUE)

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -88,6 +88,7 @@ Lrnr_hal9001 <- R6Class(
                           return_x_basis = FALSE,
                           basis_list = NULL,
                           cv_select = TRUE,
+                          squash = TRUE,
                           ...) {
       params <- args_to_list()
       super$initialize(params = params, ...)
@@ -122,6 +123,9 @@ Lrnr_hal9001 <- R6Class(
       }
 
       fit_object <- call_with_args(hal9001::fit_hal, args, keep_all = TRUE)
+      if(self$params$squash) {
+        fit_object <- hal9001::squash_hal_fit(fit_object)
+       }
       return(fit_object)
     },
     .predict = function(task = NULL) {

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -70,6 +70,8 @@
 #'    to \code{TRUE}) or to fit along the sequence of values (or a single value
 #'    using \code{\link[glmnet]{glmnet}} (when set to \code{FALSE}).
 #'   }
+#'   \item{\code{squash=TRUE}}{A \code{logical} specifying whether to call \code{\link[hal9001]{squash_hal_fit}} on the returned hal9001 fit object.
+#'   }
 #'   \item{\code{...}}{Other parameters passed directly to
 #'    \code{\link[hal9001]{fit_hal}}. See its documentation for details.
 #'   }

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -127,7 +127,7 @@ Lrnr_hal9001 <- R6Class(
       }
       if(!is.null(self$params$formula)) {
         args$data <- task$data
-        formula <- call_with_args(hal9001::formula_hal(self$params$formula, args), keep_all = TRUE)
+        formula <- call_with_args(hal9001::formula_hal, args, keep_all = TRUE)
         fit_object <- hal9001::fit_hal_formula(formula)
       } else {
         fit_object <- call_with_args(hal9001::fit_hal, args, keep_all = TRUE)

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -92,6 +92,7 @@ Lrnr_hal9001 <- R6Class(
                           cv_select = TRUE,
                           squash = TRUE,
                           p_reserve = 0.5,
+                          formula = NULL,
                           ...) {
       params <- args_to_list()
       super$initialize(params = params, ...)
@@ -124,8 +125,13 @@ Lrnr_hal9001 <- R6Class(
       if (task$has_node("id")) {
         args$id <- task$id
       }
-
-      fit_object <- call_with_args(hal9001::fit_hal, args, keep_all = TRUE)
+      if(!is.null(self$params$formula)) {
+        args$data <- task$data
+        formula <- call_with_args(hal9001::formula_hal(self$params$formula, args), keep_all = TRUE)
+        fit_object <- hal9001::fit_hal_formula(formula)
+      } else {
+        fit_object <- call_with_args(hal9001::fit_hal, args, keep_all = TRUE)
+      }
       if(self$params$squash) {
         fit_object <- hal9001::squash_hal_fit(fit_object)
        }

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -91,6 +91,7 @@ Lrnr_hal9001 <- R6Class(
                           basis_list = NULL,
                           cv_select = TRUE,
                           squash = TRUE,
+                          p_reserve = 0.5,
                           ...) {
       params <- args_to_list()
       super$initialize(params = params, ...)
@@ -131,7 +132,7 @@ Lrnr_hal9001 <- R6Class(
       return(fit_object)
     },
     .predict = function(task = NULL) {
-      predictions <- predict(self$fit_object, new_data = as.matrix(task$X))
+      predictions <- predict(self$fit_object, new_data = as.matrix(task$X), p_reserve = self$params$p_reserve)
       if (!is.na(safe_dim(predictions)[2])) {
         p <- ncol(predictions)
         colnames(predictions) <- sprintf("lambda_%0.3e", self$params$lambda)

--- a/R/survival_utils.R
+++ b/R/survival_utils.R
@@ -32,11 +32,17 @@ pooled_hazard_task <- function(task, trim = TRUE) {
   repeated_data <- underlying_data[index, ]
   new_folds <- origami::id_folds_to_folds(task$folds, index)
 
-  repeated_task <- task$next_in_chain(
-    column_names = column_names,
-    data = repeated_data, id = "id",
-    folds = new_folds
-  )
+  rnodes <- task$nodes
+  nodes$id <- "id"
+  repeated_task <- sl3_Task$new(repeated_data, column_names = column_names, nodes = task$nodes, folds = new_folds, outcome_levels = outcome_levels, outcome_type = task$outcome_type)
+  # If "task" has a non-null row_index then this will fail.
+  # The next_in_chain function does not reset the row_index if data is passed in.
+  # So CV learners and pooled hazards don't work
+  # repeated_task <- task$next_in_chain(
+  #   column_names = column_names,
+  #   data = repeated_data, id = "id",
+  #   folds = new_folds, row_index = NULL
+  # )
 
   # make bin indicators
   bin_number <- rep(level_index, each = task$nrow)

--- a/R/survival_utils.R
+++ b/R/survival_utils.R
@@ -32,9 +32,9 @@ pooled_hazard_task <- function(task, trim = TRUE) {
   repeated_data <- underlying_data[index, ]
   new_folds <- origami::id_folds_to_folds(task$folds, index)
 
-  rnodes <- task$nodes
+  nodes <- task$nodes
   nodes$id <- "id"
-  repeated_task <- sl3_Task$new(repeated_data, column_names = column_names, nodes = task$nodes, folds = new_folds, outcome_levels = outcome_levels, outcome_type = task$outcome_type)
+  repeated_task <- sl3_Task$new(repeated_data, column_names = column_names, nodes = task$nodes, folds = new_folds, outcome_levels = outcome_levels, outcome_type = task$outcome_type$type)
   # If "task" has a non-null row_index then this will fail.
   # The next_in_chain function does not reset the row_index if data is passed in.
   # So CV learners and pooled hazards don't work

--- a/man/Lrnr_hal9001.Rd
+++ b/man/Lrnr_hal9001.Rd
@@ -69,6 +69,8 @@ in order to pick the optimal value (based on cross-validation) (when set
 to \code{TRUE}) or to fit along the sequence of values (or a single value
 using \code{\link[glmnet]{glmnet}} (when set to \code{FALSE}).
 }
+\item{\code{squash=TRUE}}{A \code{logical} specifying whether to call \code{\link[hal9001]{squash_hal_fit}} on the returned hal9001 fit object.
+}
 \item{\code{...}}{Other parameters passed directly to
 \code{\link[hal9001]{fit_hal}}. See its documentation for details.
 }

--- a/vignettes/testing.Rmd
+++ b/vignettes/testing.Rmd
@@ -1,0 +1,89 @@
+---
+title: "Untitled"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r}
+library(sl3)
+
+
+```
+
+```{r}
+n <- 2500
+library(simcausal)
+#library(sl3)
+D <- DAG.empty()
+
+
+D <- D +
+  node("W1f", distr = "runif", min = -1, max = 1) +
+  node("W2f", distr = "runif", min = -1, max = 1) +
+  node("W3f", distr = "runif", min = -1, max = 1) +
+   node("W1", distr = "rconst", const = W1f) +
+   node("W2", distr = "rconst", const = W2f) +
+   node("W3", distr = "rconst", const = W3f) +
+  node("g", distr = "rconst", const = 0.2 + 0.65*plogis(sin(W1*5) + W1*sin(W1*5) + cos(W2*5) + 2*W1*W2 - sin(W3*5) + sin(5*W1*W3) + 2*W1*W2*W3 + W3*sin(W1*5) + cos(W2*4)*sin(W1*5) ) ) +
+  node("A", distr = "rbinom", size = 1, prob = g )+
+   node("gR", distr = "rconst",  const =  2*(W1 + W2 + W3) + A*(W1 + W2 + W3 + W1*W2 + W2*W3 + W1*W3 ) + W1*W2 + W2*W3 + W1*W3 + W1^2 -W2^2 + W3^2 ) +
+  node("R", distr = "rnorm",  mean = gR, sd = 1)
+
+setD <- set.DAG(D)
+data <- sim(setD, n = n)
+data
+
+```
+
+
+```{r}
+#call_with_args <- sl3:::call_with_args
+library(R6)
+task <- sl3_Task$new(data, covariates = c("W1", "W2", "W3", "A"), outcome  = "R")
+task$data
+
+lrnr_ranger <- Lrnr_ranger$new(num.trees = 50, predict.all = TRUE )
+lrnr_ranger <- lrnr_ranger$train(task) 
+data.table::as.data.table(lrnr_ranger$predict(task))
+```
+
+
+
+```{r}
+lrnr_xgboost <- Lrnr_xgboost$new(nrounds  = 20, predict.all.trees = FALSE )
+lrnr_xgboost <- lrnr_xgboost$train(task) 
+data.table::as.data.table(lrnr_xgboost$predict(task))
+
+lrnr_xgboost_stacked <- make_learner(Pipeline, Lrnr_cv$new(Lrnr_xgboost$new(nrounds  = 20, predict.all.trees = TRUE )), Lrnr_nnls$new(convex = FALSE))
+lrnr_xgboost_stacked <- lrnr_xgboost_stacked$train(task)
+data.table::as.data.table(lrnr_xgboost_stacked$predict(task))
+```
+
+
+```{r}
+
+lrnr_xg_stack <- make_learner(Stack, Lrnr_xgboost$new(nrounds  = 20, predict.all.rounds = TRUE, max_depth = 3 ), Lrnr_xgboost$new(nrounds  = 20, predict.all.rounds = TRUE, max_depth = 5 ),
+             Lrnr_xgboost$new(nrounds  = 20, predict.all.rounds = TRUE, max_depth = 7 ),
+             Lrnr_xgboost$new(nrounds  = 20, predict.all.rounds = TRUE, max_depth = 10 ))
+lrnr_xg_stack <- Lrnr_sl$new(lrnr_xg_stack, metalearner = Lrnr_$new())
+```
+```{r}
+lrnr_stack <- make_learner(Stack,
+                           Lrnr_xgboost$new(nrounds  = 20, predict.all.trees = FALSE, max_depth = 3 ),
+                           Lrnr_xgboost$new(nrounds  = 20, predict.all.trees = FALSE, max_depth = 5 ),
+                           Lrnr_xgboost$new(nrounds  = 20, predict.all.trees = FALSE, max_depth = 7 ), Lrnr_xgboost$new(nrounds  = 20, predict.all.trees = FALSE, max_depth = 10 ), lrnr_xg_stack)
+lrnr_stack <- lrnr_stack$train(task)
+preds <- lrnr_stack$predict(task)
+as.data.frame(apply(preds - data$gR, 2, function(v) {mean(v^2)}))
+#lrnr_cv <- Lrnr_cv$new(lrnr_stack)
+#lrnr_cv <- lrnr_cv$train(task)
+#lrnr_cv$cv_risk(loss_squared_error)
+```
+
+
+
+
+


### PR DESCRIPTION
Pooled hazards task does not work as intended (or errors) when using tasks that have non-null row_index internal variables. This occurs because when passing in a new dataset to next_in_chain, it does not reset the internal row_index variable. This makes using CV learners that utilize pooled hazards tasks internally (e.g. Lrnr_cv$new(Lrnr_pooled_hazards$new())) break down. For tmle3 survival, the pooled hazards task was created externally as the main task, so the hazard estimation with CV was not impacted by this bug. 

It might also be worth changing sl3_Task so that row_index is reset when passing in a new dataset. Or, maybe we should just not allow datasets to be passed in through next_in_chain.

Also, changed Lrnr_hal9001 so that all params are passed into fit_hal.

Also, added squash option for Lrnr_hal9001 to reduce computation time.