### PR TITLE
Fix `Lrnr_lightgbm` test on Windows

### DIFF
--- a/R/Lrnr_lightgbm.R
+++ b/R/Lrnr_lightgbm.R
@@ -25,6 +25,9 @@
 #'
 #' @section Parameters:
 #'   - \code{num_threads = 1L}: Number of threads for hyperthreading.
+#'   - \code{verbose = -1}: Verbosity for output. This differs from the default
+#'       in \code{\link[lightgbm]{lgb.train}}, disableing the printing of all
+#'       messages, including evaluation during training.
 #'   - \code{...}: Other arguments passed to \code{\link[lightgbm]{lgb.train}}.
 #'       See its documentation for further details.
 #'
@@ -32,7 +35,7 @@ Lrnr_lightgbm <- R6Class(
   classname = "Lrnr_lightgbm", inherit = Lrnr_base,
   portable = TRUE, class = TRUE,
   public = list(
-    initialize = function(num_threads = 1L, ...) {
+    initialize = function(num_threads = 1L, verbose = -1, ...) {
       params <- args_to_list()
       super$initialize(params = params, ...)
     },

--- a/man/Lrnr_lightgbm.Rd
+++ b/man/Lrnr_lightgbm.Rd
@@ -23,6 +23,9 @@ consult the documentation of the \pkg{lightgbm} package.
 
 \itemize{
 \item \code{num_threads = 1L}: Number of threads for hyperthreading.
+\item \code{verbose = -1}: Verbosity for output. This differs from the default
+in \code{\link[lightgbm]{lgb.train}}, disableing the printing of all
+messages, including evaluation during training.
 \item \code{...}: Other arguments passed to \code{\link[lightgbm]{lgb.train}}.
 See its documentation for further details.
 }

--- a/tests/testthat/test-cv.R
+++ b/tests/testthat/test-cv.R
@@ -4,7 +4,8 @@ library(origami)
 options(java.parameters = "-Xmx2500m")
 
 data(cpp_imputed)
-covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs", "sexn")
+covars <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs",
+            "sexn")
 outcome <- "haz"
 task <- sl3_Task$new(cpp_imputed, covariates = covars, outcome = outcome)
 
@@ -83,7 +84,7 @@ cv_risk_table <- fit$cv_risk(loss_squared_error)
 expect_equal(cv_risk_table$coefficients[[1]], 1)
 expect_equal(cv_risk_table$risk[[1]], 0)
 
-################################# test LOOCV ###################################
+################################ test LOOCV ###################################
 test_loocv_learner <- function(learner, loocv_task, ...) {
   learner_obj <- make_learner(learner, ...)
   print(sprintf("Testing LOOCV with Learner: %s", learner_obj$name))
@@ -104,7 +105,8 @@ test_loocv_learner <- function(learner, loocv_task, ...) {
 
   # test learner chaining
   chained_task <- fit_obj$chain()
-  test_that("Chaining returns a task", expect_true(is(chained_task, "sl3_Task")))
+  test_that("Chaining returns a task", expect_true(is(chained_task,
+                                                      "sl3_Task")))
   test_that("Chaining returns the correct number of rows", expect_equal(
     nrow(chained_task$X),
     nrow(loocv_task$X)
@@ -114,7 +116,8 @@ test_loocv_learner <- function(learner, loocv_task, ...) {
   preds_full <- fit_obj$predict_fold(loocv_task, "full")
   preds_valid <- fit_obj$predict_fold(loocv_task, "validation")
   validation_task <- validation(loocv_task, fold = loocv_task$folds[[1]])
-  validation_preds <- fit_obj$fit_object$fold_fits[[1]]$predict(validation_task)
+  validation_preds <-
+    fit_obj$fit_object$fold_fits[[1]]$predict(validation_task)
   test_that("Learners do not error under LOOCV", {
     expect_false(any(is.na(preds_valid)))
     expect_false(any(is.na(preds_fold1)))
@@ -125,7 +128,9 @@ test_loocv_learner <- function(learner, loocv_task, ...) {
 
 # make task with LOOCV
 d <- cpp_imputed[1:50, ]
-expect_warning(loocv_folds <- make_folds(n = d, fold_fun = folds_vfold, V = 50))
+expect_warning(
+  loocv_folds <- make_folds(n = d, fold_fun = folds_vfold, V = 50)
+)
 loocv_task <- sl3_Task$new(d, covars, outcome, folds = loocv_folds)
 
 # get learners


### PR DESCRIPTION
In the LOO-CV unit test, `Lrnr_lightgbm` outputs a number of warnings related to its training. My guess is that Appveyor is failing because it might be parsing the log file to check for warnings while/after the test output is created, issuing a failure based on these non-essential warnings. This PR adjusts the `verbose` argument of `Lrnr_lightgbm` to suppress the message output of `lgb.train` by default.