### PR TITLE
Expand `call_with_args` arguments in `Lrnr_hal9001`

### DIFF
--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -122,7 +122,7 @@ Lrnr_hal9001 <- R6Class(
       }
 
       # pass in formals of glmnet versus cv.glmnet based on cv_select
-      if (cv_select) {
+      if (args$cv_select) {
         glmnet_other_valid <- names(formals(glmnet::cv.glmnet))
       } else {
         glmnet_other_valid <- names(formals(glmnet::glmnet))

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -121,7 +121,18 @@ Lrnr_hal9001 <- R6Class(
         args$id <- task$id
       }
 
-      fit_object <- call_with_args(hal9001::fit_hal, args)
+      # pass in formals of glmnet versus cv.glmnet based on cv_select
+      if (cv_select) {
+        glmnet_other_valid <- names(formals(glmnet::cv.glmnet))
+      } else {
+        glmnet_other_valid <- names(formals(glmnet::glmnet))
+      }
+
+      # fit HAL, allowing glmnet-fitting arguments
+      fit_object <- call_with_args(
+        hal9001::fit_hal, args,
+        other_valid = glmnet_other_valid
+      )
       return(fit_object)
     },
     .predict = function(task = NULL) {
@@ -132,6 +143,6 @@ Lrnr_hal9001 <- R6Class(
       }
       return(predictions)
     },
-    .required_packages = c("hal9001")
+    .required_packages = c("hal9001", "glmnet")
   )
 )

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -123,7 +123,10 @@ Lrnr_hal9001 <- R6Class(
 
       # pass in formals of glmnet versus cv.glmnet based on cv_select
       if (args$cv_select) {
-        glmnet_other_valid <- names(formals(glmnet::cv.glmnet))
+        glmnet_other_valid <- union(
+          names(formals(glmnet::cv.glmnet)),
+          names(formals(glmnet::glmnet))
+        )
       } else {
         glmnet_other_valid <- names(formals(glmnet::glmnet))
       }


### PR DESCRIPTION
Allow `glmnet` arguments through `...` in `fit_hal` via `Lrnr_hal9001`'s `call_with_args`. This just passed `names(formals(glmnet))` or `names(formals(cv.glmnet))` to `call_with_args` as appropriate.