### PR TITLE
Disable LightGBM testing on Windows

### DIFF
--- a/man/Lrnr_haldensify.Rd
+++ b/man/Lrnr_haldensify.Rd
@@ -33,6 +33,15 @@ to be divided into.
 sequence of values of the regulariztion parameter of the Lasso regression,
 to be passed to to \code{\link[hal9001]{fit_hal}}.
 }
+\item{\code{trim_dens = 1/sqrt(n)}}{A \code{numeric} giving the minimum
+allowed value of the resultant density predictions. Any predicted
+density values below this tolerance threshold are set to the indicated
+minimum. The default is to use the inverse of the square root of the
+sample size of the prediction set, i.e., 1/sqrt(n); another notable
+choice is 1/sqrt(n)/log(n). If there are observations in the prediction
+set with values of \code{new_A} outside of the support of the training
+set, their predictions are similarly truncated.
+}
 \item{\code{...}}{ Other parameters passed directly to
 \code{\link[haldensify]{haldensify}}. See its documentation for details.
 }

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -11,28 +11,29 @@ task <- sl3_Task$new(cpp_imputed, covariates = covars, outcome = outcome)
 test_learner <- function(learner, task, ...) {
   # test learner definition: this requires that a learner can be instantiated
   # with only default arguments. Not sure if this is a reasonable requirement
-  learner_obj <- learner$new(...)
   print(sprintf("Testing Learner: %s", learner_obj$name))
+
   # test learner training
-  fit_obj <- learner_obj$train(task)
   test_that("Learner can be trained on data", {
     skip_on_os("windows")
+    learner_obj <- learner$new(...)
+    fit_obj <- learner_obj$train(task)
     expect_true(fit_obj$is_trained)
   })
 
   # test learner prediction
-  train_preds <- fit_obj$predict()
   test_that("Learner can generate training set predictions", {
     skip_on_os("windows")
+    train_preds <- fit_obj$predict()
     expect_equal(
       sl3:::safe_dim(train_preds)[1], length(task$Y)
     )
   })
 
   # test learner chaining
-  chained_task <- fit_obj$chain()
   test_that("Chaining returns a task", {
     skip_on_os("windows")
+    chained_task <- fit_obj$chain()
     expect_true(is(chained_task, "sl3_Task"))
   })
   test_that("Chaining returns the correct number of rows", {

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -24,6 +24,7 @@ test_learner <- function(learner, task, ...) {
   # test learner prediction
   test_that("Learner can generate training set predictions", {
     skip_on_os("windows")
+    fit_obj <- learner_obj$train(task)
     train_preds <- fit_obj$predict()
     expect_equal(
       sl3:::safe_dim(train_preds)[1], length(task$Y)
@@ -33,11 +34,15 @@ test_learner <- function(learner, task, ...) {
   # test learner chaining
   test_that("Chaining returns a task", {
     skip_on_os("windows")
+    fit_obj <- learner_obj$train(task)
     chained_task <- fit_obj$chain()
     expect_true(is(chained_task, "sl3_Task"))
   })
+
   test_that("Chaining returns the correct number of rows", {
     skip_on_os("windows")
+    fit_obj <- learner_obj$train(task)
+    chained_task <- fit_obj$chain()
     expect_equal(nrow(chained_task$X), nrow(task$X))
   })
 }

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -11,12 +11,12 @@ task <- sl3_Task$new(cpp_imputed, covariates = covars, outcome = outcome)
 test_learner <- function(learner, task, ...) {
   # test learner definition: this requires that a learner can be instantiated
   # with only default arguments. Not sure if this is a reasonable requirement
+  learner_obj <- learner$new(...)
   print(sprintf("Testing Learner: %s", learner_obj$name))
 
   # test learner training
   test_that("Learner can be trained on data", {
     skip_on_os("windows")
-    learner_obj <- learner$new(...)
     fit_obj <- learner_obj$train(task)
     expect_true(fit_obj$is_trained)
   })

--- a/tests/testthat/test-screeners.R
+++ b/tests/testthat/test-screeners.R
@@ -109,7 +109,16 @@ test_importance_screener <- function(learner) {
 }
 
 test_that("Lrnr_screener_importance tests", {
+  # get all learners supporting variable importance
   importance_learners <- sl3::sl3_list_learners("importance")
+
+  # remove LightGBM on Windows
+  if (Sys.info()["sysname"] == "Windows") {
+    importance_learners <-
+      importance_learners[!(importance_learners == "Lrnr_lightgbm")]
+  }
+
+  # test all learners supporting variable importance
   lapply(importance_learners, test_importance_screener)
 })
 


### PR DESCRIPTION
LightGBM doesn't work on Windows currently. See #344 for more details. Just disabling tests here.