### PR TITLE
Minor fix to formula

### DIFF
--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -322,14 +322,15 @@ Lrnr_base <- R6Class(
 
         # get data corresponding to formula and add new columns to the task
         data <- as.data.table(stats::model.matrix(form, data = task$data))
-        new_cols <- setdiff(names(data), names(task$data))
-        if (any(grepl("Intercept", new_cols))) {
-          new_cols <- new_cols[!grepl("Intercept", new_cols)]
+        formula_cols <- names(data)
+        if (any(grepl("Intercept", formula_cols))) {
+          formula_cols <- formula_cols[!grepl("Intercept", formula_cols)]
         }
+        new_cols <- setdiff(formula_cols, names(task$data))
         data <- data[, new_cols, with = FALSE]
         new_cols <- task$add_columns(data)
         return(
-          task$next_in_chain(covariates = names(data), column_names = new_cols)
+          task$next_in_chain(covariates = formula_cols, column_names = new_cols)
         )
       } else {
         return(task)


### PR DESCRIPTION
When `process_formula` calls `task$next_in_chain()` to update the task with the new covariates in the formula, it now sets the covariates as *all* of the terms in the formula. Before, we were setting the covariates as the *new* terms in the formula that were not previously covariates in the task, which led to dropping of those existing covariates.