### PR TITLE
Lrnr Formula bug fix

### DIFF
--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -304,7 +304,7 @@ Lrnr_base <- R6Class(
         if (class(form) != "formula") form <- as.formula(form)
 
         # check response variable corresponds to outcome in task, if provided
-        if (attr(terms(form), "response")) {
+        if (attr(terms(form, data = task$data), "response")) {
           if (!all.vars(form)[1] == task$nodes$outcome) {
             stop(paste0(
               "Outcome variable in formula ", all.vars(form)[1],

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -322,7 +322,8 @@ Lrnr_base <- R6Class(
         }
 
         # get data corresponding to formula and add new columns to the task
-        data <- as.data.table(stats::model.matrix(form, data = task$data))
+        # Passing in X ensures that the outcome is not included in model if "~." is used without specifying outcome
+        data <- as.data.table(stats::model.matrix(form, data = task$X))  
         all_cols <- unique(names(data))
         new_cols <- setdiff(names(data), names(task$data))
         if (any(grepl("Intercept", new_cols))) {

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -316,7 +316,8 @@ Lrnr_base <- R6Class(
           formula_covars <- all.vars(form)
         }
         # check that regressors in the formula are contained in the task
-        if (!all(formula_covars %in% task$nodes$covariates)) {
+        # If "." in formula weird stuff happens. Setdiff is a tentative fix.
+        if (!all(setdiff(formula_covars, ".") %in% task$nodes$covariates)) {
           stop("Regressors in the formula are not covariates in task")
         }
 

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -322,14 +322,16 @@ Lrnr_base <- R6Class(
 
         # get data corresponding to formula and add new columns to the task
         data <- as.data.table(stats::model.matrix(form, data = task$data))
+        all_cols <- unique(names(data))
         new_cols <- setdiff(names(data), names(task$data))
         if (any(grepl("Intercept", new_cols))) {
           new_cols <- new_cols[!grepl("Intercept", new_cols)]
+          all_cols <- all_cols[!grepl("Intercept", all_cols)]
         }
         data <- data[, new_cols, with = FALSE]
         new_cols <- task$add_columns(data)
         return(
-          task$next_in_chain(covariates = names(data), column_names = new_cols)
+          task$next_in_chain(covariates = all_cols, column_names = new_cols)
         )
       } else {
         return(task)


### PR DESCRIPTION
It previously added new_cols as the only covariates for the new task. So if the formula was "~.", an empty task was returned.

Also, it seems that `terms(form)` requires a data object if "." appears in the formula, which also led to an error.

(I didn't realize sl3 had this formula feature. This is great.)