### PR TITLE
[WIP] fit size reduction

### DIFF
--- a/R/Lrnr_glm_fast.R
+++ b/R/Lrnr_glm_fast.R
@@ -157,7 +157,7 @@ Lrnr_glm_fast <- R6Class(
       }
       return(predictions)
     },
-    .fit_can_remove = c("XTX"),
+    .fit_can_remove = c("XTX", "offset"),
     .required_packages = c("speedglm")
   )
 )

--- a/R/Lrnr_glm_fast.R
+++ b/R/Lrnr_glm_fast.R
@@ -157,6 +157,7 @@ Lrnr_glm_fast <- R6Class(
       }
       return(predictions)
     },
+    .fit_can_remove = c("XTX"),
     .required_packages = c("speedglm")
   )
 )

--- a/R/Lrnr_hal9001.R
+++ b/R/Lrnr_hal9001.R
@@ -99,7 +99,6 @@ Lrnr_hal9001 <- R6Class(
 
       return(fit_object)
     },
-
     .predict = function(task = NULL) {
       predictions <- stats::predict(
         self$fit_object,
@@ -111,7 +110,7 @@ Lrnr_hal9001 <- R6Class(
       }
       return(predictions)
     },
-
+    .fit_can_remove = c("lasso_fit", "x_basis"),
     .required_packages = c("hal9001", "glmnet")
   )
 )

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -194,6 +194,7 @@ Lrnr_xgboost <- R6Class(
 
       return(predictions)
     },
+    .fit_can_remove = c("raw", "call"),
     .required_packages = c("xgboost")
   )
 )

--- a/R/utils.R
+++ b/R/utils.R
@@ -155,6 +155,16 @@ true_obj_size <- function(obj) {
   length(serialize(obj, NULL))
 }
 
+#' @keywords internal
+check_fit_sizes <- function(fit) {
+  fo <- fit$fit_object
+  # see what's taking up the space
+  element_sizes <- sapply(fo, true_obj_size)
+  ranked <- sort(element_sizes / sum(element_sizes), decreasing = TRUE)
+
+  return(ranked)
+}
+
 ################################################################################
 
 #' Drop components from learner fits

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -38,8 +38,7 @@ sl3Options <- function(o, value) {
     }
     if (is.null(value)) {
       res[o] <- list(NULL)
-    }
-    else {
+    } else {
       res[[o]] <- value
     }
     options(res[o])
@@ -62,7 +61,8 @@ sl3Options <- function(o, value) {
     "sl3.pcontinuous" = 0.05,
     "sl3.max_p_missing" = 0.5,
     "sl3.transform.offset" = TRUE,
-    "sl3.enable.future" = TRUE
+    "sl3.enable.future" = TRUE,
+    "sl3.reduce_fit" = FALSE
   )
   # for (i in setdiff(names(opts),names(options()))) {
   #   browser()

--- a/tests/testthat/test-reduce_fit.R
+++ b/tests/testthat/test-reduce_fit.R
@@ -2,7 +2,7 @@
 set.seed(1234)
 
 # TODO: maybe check storage at different n to get rate
-n <- 1e3
+n <- 1e4
 p <- 100
 # these two define the DGP (randomly)
 p_X <- runif(p, 0.2, 0.8)

--- a/tests/testthat/test-reduce_fit.R
+++ b/tests/testthat/test-reduce_fit.R
@@ -1,0 +1,44 @@
+
+set.seed(1234)
+
+# TODO: maybe check storage at different n to get rate
+n <- 1e3
+p <- 100
+# these two define the DGP (randomly)
+p_X <- runif(p, 0.2, 0.8)
+beta <- rnorm(p)
+
+# simulate from the DGP
+X <- sapply(p_X, function(p_Xi) rbinom(n, 1, p_Xi))
+p_Yx <- plogis(X %*% beta)
+Y <- rbinom(n, 1, p_Yx)
+data <- data.table(X, Y)
+
+# generate the sl3 task and learner
+outcome <- "Y"
+covariates <- setdiff(names(data), outcome)
+task <- make_sl3_Task(data, covariates, outcome)
+
+options(sl3.verbose = TRUE)
+options(sl3.reduce_fit = TRUE)
+test_reduce_fit <- function(learner) {
+  fit <- learner$train(task)
+  print(sl3:::check_fit_sizes(fit))
+  if (!getOption("sl3.reduce_fit")) {
+    # if we aren't automatically reducing, do it manually
+    fit_object <- fit$reduce_fit()
+  }
+
+  still_present <- intersect(
+    names(fit$fit_object),
+    fit$.__enclos_env__$private$.fit_can_remove
+  )
+
+  expect_equal(length(still_present), 0)
+}
+
+test_reduce_fit(make_learner(Lrnr_glmnet))
+test_reduce_fit(make_learner(Lrnr_ranger))
+test_reduce_fit(make_learner(Lrnr_glm_fast))
+test_reduce_fit(make_learner(Lrnr_xgboost))
+test_reduce_fit(make_learner(Lrnr_hal9001))


### PR DESCRIPTION
WIP PR that adds `Lrnr_base$reduce_fit` to drop `fit_object` components not necessary for prediction, reducing memory demands.

In response to https://github.com/tlverse/sl3/issues/12

* Implements `Lrnr_base$reduce_fit`, which drops out `fit_object` components 
* Adds `private$.fit_can_remove`, which takes a character vector of `fit_object` components not necessary for prediction
* Adds `options("sl3.reduce_fit")` If true, we automatically call `reduce_fit` as part of the training process
* Adds `test-reduce-fit.R`, tests fit reduction for a few learners that I've verified so far