### PR TITLE
`Lrnr_bound` automatically sets upper bound

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -106,5 +106,5 @@ VignetteBuilder:
     knitr,
     R.rsp
 Roxygen: list(markdown = TRUE, old_usage = TRUE, r6 = FALSE)
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 RdMacros: Rdpack

--- a/R/Lrnr_bound.R
+++ b/R/Lrnr_bound.R
@@ -61,11 +61,12 @@ Lrnr_bound <- R6Class(
       outcome_type <- self$get_outcome_type(task)
 
       # check compatibility of bounding limits with outcome type
-      if (outcome_type$type == "continuous") {
-        assertthat::assert_that(
-          length(args$bound) > 1,
-          msg = "Both upper and lower bounds required for continous outcomes."
-        )
+      if (outcome_type$type == "continuous" && length(args$bound) == 1L) {
+        message(paste(
+          "Outcome is", outcome_type$type, "but only lower bound specified.",
+          "Setting upper bound to infinity."
+        ))
+        private$.params$bound[2] <- Inf
       }
       fit_object <- list()
       return(fit_object)


### PR DESCRIPTION
the upper bound can be automatically set for continuous outcomes when it is detected to be missing. this seems a more robust solution that throwing an error, which is what i ran into