### PR TITLE
Remove extraneous spaces

### DIFF
--- a/R/Lrnr_arima.R
+++ b/R/Lrnr_arima.R
@@ -87,8 +87,8 @@ Lrnr_arima <- R6Class(
         if (length(rm_idx) > 0) {
           params$xreg <- as.matrix(task$X[, -rm_idx, with = FALSE])
           print(paste(c(
-            "ARIMA requires matrix of external regressors to not be rank ",
-            "deficient. The following covariates were removed to counter the ",
+            "ARIMA requires matrix of external regressors to not be rank",
+            "deficient. The following covariates were removed to counter the",
             "linear combinations:", names(task$X)[rm_idx]
           ), collapse = " "))
         } else {


### PR DESCRIPTION
Also, should this really be print()'ed? it comes out looking like:

```
[1] "ARIMA requires matrix of external regressors to not be rank  deficient. The following covariates were removed to counter the  linear combinations: cnt"
```

Is that intentional? Should it be `cat()`'d, or `message()`'d instead?

Lastly, is the intention to print the full message for each of the `rm_idx`? Or maybe this is better:

```
message(
  "ARIMA requires matrix of external regressors to not be rank ",
  "deficient. The following covariates were removed to counter the ",
  "linear combinations: ", toString(names(task$X)[rm_idx])
)
```