### PR TITLE
Factor to indicators error message

### DIFF
--- a/R/multinomial_helpers.R
+++ b/R/multinomial_helpers.R
@@ -45,11 +45,6 @@ normalize_rows <- function(x) {
 #' @export
 factor_to_indicators <- function(x, ind_ref_mat = NULL) {
   x_vals <- get_levels(x)
-  
-  if (length(x_vals) == 1L) {
-    stop("Categorical variables must have more than one levels")
-  }
-  
   if (is.null(ind_ref_mat)) {
     ind_ref_mat <- sapply(x_vals[-1], function(x_val) as.numeric(x_val == x_vals))
   }

--- a/R/multinomial_helpers.R
+++ b/R/multinomial_helpers.R
@@ -45,6 +45,11 @@ normalize_rows <- function(x) {
 #' @export
 factor_to_indicators <- function(x, ind_ref_mat = NULL) {
   x_vals <- get_levels(x)
+  
+  if (length(x_vals) == 1L) {
+    stop("Categorical variables must have more than one levels")
+  }
+  
   if (is.null(ind_ref_mat)) {
     ind_ref_mat <- sapply(x_vals[-1], function(x_val) as.numeric(x_val == x_vals))
   }

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -98,22 +98,15 @@ process_data <- function(data, nodes, column_names, flag = TRUE,
   }
 
   # check for single level/value covariates and outcome
-  single_level_covs <- names(which(data[, sapply(.SD, function(x) uniqueN(x) == 1L), .SDcols = covariates_columns]))
-  if (length(single_level_covs) > 0) {
-    warning(sprintf(
-        "Dropping the following covariates as they are constant, with only one unique category/value: %s.",
-        paste0(single_level_covs, collapse = ", ")
-    ))
-    # drop constant covariates from data, covariates, all_nodes, and node_columns
-    covariates_columns <- covariates_columns[-which(covariates_columns %in% single_level_covs)]
-    nodes$covariates <- covariates_columns
-    all_nodes <- unlist(nodes)
-    node_columns <- unlist(column_names[all_nodes])
-    data <- data[, -single_level_covs, with=FALSE]
-    if(!is.null(column_names) && any(single_level_covs %in% column_names)){
-      column_names <- column_names[-which(column_names %in% single_level_covs)]
+  if(!is.null(nodes$covariates)){
+    single_level_covs <- names(which(data[, sapply(.SD, function(x) uniqueN(x) == 1L), .SDcols = covariates_columns]))
+    if (length(single_level_covs) > 0) {
+      warning(sprintf(
+          "The following covariates are constant, with only one unique category/value: %s.",
+          paste0(single_level_covs, collapse = ", ")
+      ))
     }
-  }
+  }                                                
                                                  
   if(!is.null(nodes$outcome)){
     single_level_outcome <- names(which(data[, sapply(.SD, function(x) uniqueN(x) == 1L), .SDcols = outcome_columns]))

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -97,6 +97,16 @@ process_data <- function(data, nodes, column_names, flag = TRUE,
     factorized <- TRUE
   }
 
+  # check for single level/value covariates
+  is_single_level <- which(data[, sapply(.SD, function(x) uniqueN(x) == 1L),
+                                .SDcols = c(covariates_columns, outcome_columns)])
+  
+  if (length(is_single_level) != 0) {
+    single_level_covs <- column_names[is_single_level]
+    stop(paste(c(paste(single_level_covs, collapse = ", "), 
+                 "must have more than one category or unique value\n"), collapse = " "))
+  }
+  
   # process missing
   has_missing <- data[, sapply(.SD, function(x) any(is.na(x))), .SDcols = node_columns]
   miss_cols <- node_columns[has_missing]

--- a/tests/testthat/test-bartMachine.R
+++ b/tests/testthat/test-bartMachine.R
@@ -1,38 +1,51 @@
 context("test-bartMachine.R -- Lrnr_bartMachine")
 
-test_that("Lrnr_bartMachine produces warning when java parameters are not set", {
-  expect_warning(Lrnr_bartMachine$new())
-})
-
-
+library(bartMachine)
 data(cpp_imputed)
-covs <- c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs", "sexn")
-outcome <- "haz"
-task <- sl3_Task$new(cpp_imputed, covariates = covs, outcome = outcome)
+
+if (is.null(getOption("java.parameters"))) {
+  test_that("Lrnr_bartMachine warns when java parameters are not set", {
+    expect_warning(Lrnr_bartMachine$new())
+  })
+}
 
 test_that("Lrnr_bartMachine produces results matching those of bartMachine::bartMachine", {
+  cpp_task <- sl3_Task$new(
+    data = cpp_imputed, 
+    covariates =  c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs", "sexn"), 
+    outcome = "haz"
+  )
+  
   # sl3 fit
   lrnr_bartMachine <- suppressWarnings(Lrnr_bartMachine$new(
     seed = 196, verbose = FALSE
   ))
-  fit_sl3 <- lrnr_bartMachine$train(task)
-  preds_sl3 <- fit_sl3$predict(task)
+  fit_sl3 <- lrnr_bartMachine$train(cpp_task)
+  preds_sl3 <- fit_sl3$predict()
 
   # classic fit
+  X <- data.frame(cpp_task$X)
+  y <- cpp_task$Y
   fit_classic <- bartMachine::bartMachine(
-    X = data.frame(task$X), y = task$Y, seed = 196, verbose = FALSE
+    X = X, y = y, seed = 196, verbose = FALSE
   )
-  preds_classic <- as.numeric(predict(fit_classic, new_data = task$X))
+  preds_classic <- as.numeric(predict(fit_classic, new_data = X))
 
   # check equality
   expect_equal(preds_sl3, preds_classic)
 })
 
-# test Lrnr_bartMachine does not fail when cross-validated
-lrnr_bartMachine <- suppressWarnings(make_learner(
-  Lrnr_bartMachine,
-  verbose = FALSE
-))
-cv_lrnr_bartMachine <- Lrnr_cv$new(lrnr_bartMachine)
-fit_cv <- cv_lrnr_bartMachine$train(task)
-preds_cv <- fit_cv$predict(task)
+test_that("Lrnr_bartMachine can be cross-validated", {
+  cpp_task <- sl3_Task$new(
+    data = cpp_imputed, 
+    covariates =  c("apgar1", "apgar5", "parity", "gagebrth", "mage", "meducyrs", "sexn"), 
+    outcome = "haz",
+    folds = 2
+  )
+  # test Lrnr_bartMachine does not fail when cross-validated
+  lrnr_bartMachine <- Lrnr_bartMachine$new(verbose = FALSE)
+  cv_lrnr_bartMachine <- Lrnr_cv$new(lrnr_bartMachine)
+  fit_cv <- cv_lrnr_bartMachine$train(cpp_task)
+  preds_cv <- fit_cv$predict()
+  expect_equal(length(preds_cv), nrow(cpp_imputed))
+})


### PR DESCRIPTION
Fix issue #285. In addition, I added a check to ensure all covariates and outcomes have more than one category (categorical variable) or unique value (continuous variable). Code will fail immediately if users try to define an sl3_Task with data that contains columns with one value. An error message indicating the names of those columns will be printed.