### PR TITLE
Fix bug with Lrnr_grf predictions

### DIFF
--- a/R/Lrnr_grf.R
+++ b/R/Lrnr_grf.R
@@ -125,7 +125,7 @@ Lrnr_grf <- R6Class(
       # generate predictions and output
       predictions_list <- stats::predict(
         private$.fit_object,
-        new_data = data.frame(task$X),
+        newdata = data.frame(task$X),
         quantiles = quantiles_pred
       )
       predictions <- as.numeric(predictions_list$predictions)


### PR DESCRIPTION
The .predict method for Lrnr_grf had an incorrect argument name for `grf::predict.quantile_forest`: the argument for supplying new data should be called `newdata` instead of `new_data` (see https://grf-labs.github.io/grf/reference/predict.quantile_forest.html).