### PR TITLE
simplify prediction output for `Lrnr_solnp_density`

### DIFF
--- a/R/Lrnr_solnp_density.R
+++ b/R/Lrnr_solnp_density.R
@@ -79,17 +79,16 @@ Lrnr_solnp_density <- R6Class(
       if (task$nrow > 0) {
         coef <- private$.fit_object$coef
         if (!all(is.na(coef))) {
-          predictions <- as.numeric(as.matrix(task$X
-          [,
-            which(!is.na(coef)),
-            drop = FALSE, with = FALSE
-          ]) %*%
-          coef[!is.na(coef)])
+          predictions <- as.numeric(
+            as.matrix(
+              task$X[, which(!is.na(coef)), drop = FALSE, with = FALSE]
+            )
+            %*% coef[!is.na(coef)]
+          )
         } else {
           stop("all SL model coefficients are NA.")
         }
       }
-      browser()
       return(predictions)
     },
     .required_packages = c("Rsolnp")

--- a/R/Lrnr_solnp_density.R
+++ b/R/Lrnr_solnp_density.R
@@ -89,7 +89,7 @@ Lrnr_solnp_density <- R6Class(
         } else {
           stop("all SL model coefficients are NA.")
         }
-        setnames(predictions, "likelihood")
+        #setnames(predictions, "likelihood")
       }
       return(predictions)
     },

--- a/R/Lrnr_solnp_density.R
+++ b/R/Lrnr_solnp_density.R
@@ -75,22 +75,21 @@ Lrnr_solnp_density <- R6Class(
     },
     .predict = function(task = NULL) {
       verbose <- getOption("sl3.verbose")
-      X <- task$X
-      predictions <- rep.int(NA, nrow(X))
-      if (nrow(X) > 0) {
+      predictions <- rep.int(NA, task$nrow)
+      if (task$nrow > 0) {
         coef <- private$.fit_object$coef
         if (!all(is.na(coef))) {
-          predictions <- data.table::data.table(as.matrix(X
+          predictions <- as.numeric(as.matrix(task$X
           [,
             which(!is.na(coef)),
             drop = FALSE, with = FALSE
           ]) %*%
-            coef[!is.na(coef)])
+          coef[!is.na(coef)])
         } else {
           stop("all SL model coefficients are NA.")
         }
-        #setnames(predictions, "likelihood")
       }
+      browser()
       return(predictions)
     },
     .required_packages = c("Rsolnp")


### PR DESCRIPTION
`Lrnr_solnp_density`'s `predict()` method contained a call to `setnames` that resulted in the outputted predictions being contained in a list rather than as a vector when this metalearner was used.