### PR TITLE
Quasibinomial family fixes

### DIFF
--- a/R/Lrnr_glm.R
+++ b/R/Lrnr_glm.R
@@ -73,7 +73,6 @@ Lrnr_glm <- R6Class(
       }
       args$y <- outcome_type$format(task$Y)
 
-
       if (task$has_node("weights")) {
         args$weights <- task$weights
       }

--- a/R/Lrnr_svm.R
+++ b/R/Lrnr_svm.R
@@ -85,7 +85,7 @@ Lrnr_svm <- R6Class(
       # set SVM type based on detected outcome family
       outcome_type <- self$get_outcome_type(task)
       if (is.null(args$type)) {
-        if (outcome_type$type == "continuous") {
+        if (outcome_type$type %in% c("continuous", "quasibinomial")) {
           args$type <- "eps-regression"
         } else if (outcome_type$type %in% c("binomial", "categorical")) {
           args$type <- "C-classification"
@@ -126,7 +126,7 @@ Lrnr_svm <- R6Class(
         if (outcome_type == "categorical") {
           predictions <- pack_predictions(predictions)
         } else if (outcome_type == "binomial") {
-          predictions <- as.numeric(predictions[, 2]) # P(Y=1|X)
+          predictions <- as.numeric(predictions[, 2])
         }
       } else {
         predictions <- as.numeric(predictions)


### PR DESCRIPTION
- allows `Lrnr_gam` to use `glm` `family` objects as described in `mgcv`'s documentation notes
- add "quasibinomial" as an option (treated as regression) for `Lrnr_svm`, bypassing breaking when set