### PR TITLE
Bug fix Lrnr_cv.R

### DIFF
--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -191,7 +191,7 @@ Lrnr_base <- R6Class(
 
       ncols <- ncol(predictions)
       if (!is.null(ncols) && (ncols == 1)) {
-        predictions <- as.vector(predictions)
+        predictions <- as.vector(unlist(predictions))
       }
       return(predictions)
     },

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -189,12 +189,15 @@ Lrnr_base <- R6Class(
       
       predictions <- private$.predict(task)
       ncols <- ncol(predictions)
-      if(inherits(predictions, "packed_predictions") & is.data.table(predictions)) {
-        # if packed and data.table, as.vector(predictions) retains list structure.
-        predictions <- as.vector(predictions)
-      } else if(!is.null(ncols) && (ncols == 1)) {
-        # otherwise return vector.
-        predictions <- as.vector(unlist(predictions))
+      if(!is.null(ncols) && (ncols == 1)) {
+        if(is.data.table(predictions)) {
+          # if a data.table of packed predictions, return a matrix.
+          predictions <- as.matrix(predictions)
+        }
+        # if not packed predictions, return vector
+        if(!inherits(predictions[[1]], "packed_predictions")) {
+          predictions <- unlist(predictions)
+        } 
       }
       return(predictions)
     },

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -198,7 +198,6 @@ Lrnr_base <- R6Class(
       }
       return(predictions)
     },
-    },
     base_chain = function(task = NULL) {
       self$assert_trained()
       if (is.null(task)) {

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -177,21 +177,25 @@ Lrnr_base <- R6Class(
         ))
       }
     },
-    base_predict = function(task = NULL) {
+     base_predict = function(task = NULL) {
       self$assert_trained()
       if (is.null(task)) {
         task <- private$.training_task
       }
-
+      
       assert_that(is(task, "sl3_Task"))
       task <- self$subset_covariates(task)
       task <- self$process_formula(task)
-
+      
       predictions <- private$.predict(task)
-
       ncols <- ncol(predictions)
-      if (!is.null(ncols) && (ncols == 1)) {
-        predictions <- as.vector(unlist(predictions))
+      if(inherits(predictions, "packed_predictions")) {
+        # if packed and data.table, as.vector(predictions) retains list structure.
+        if(is.data.table(predictions)) predictions <- as.vector(predictions)
+        return(predictions)
+      } else if(!is.null(ncols) && (ncols == 1)) {
+        # otherwise return vector.
+        predictions <- as.vector(unlist(predictions)
       }
       return(predictions)
     },

--- a/R/Lrnr_base.R
+++ b/R/Lrnr_base.R
@@ -189,15 +189,15 @@ Lrnr_base <- R6Class(
       
       predictions <- private$.predict(task)
       ncols <- ncol(predictions)
-      if(inherits(predictions, "packed_predictions")) {
+      if(inherits(predictions, "packed_predictions") & is.data.table(predictions)) {
         # if packed and data.table, as.vector(predictions) retains list structure.
-        if(is.data.table(predictions)) predictions <- as.vector(predictions)
-        return(predictions)
+        predictions <- as.vector(predictions)
       } else if(!is.null(ncols) && (ncols == 1)) {
         # otherwise return vector.
-        predictions <- as.vector(unlist(predictions)
+        predictions <- as.vector(unlist(predictions))
       }
       return(predictions)
+    },
     },
     base_chain = function(task = NULL) {
       self$assert_trained()

--- a/R/Lrnr_cv.R
+++ b/R/Lrnr_cv.R
@@ -174,6 +174,8 @@ Lrnr_cv <- R6Class(
 
 
       predictions <- self$predict_fold(revere_task, fold_number)
+      # This might not be a matrix
+      predictions <- as.data.table(predictions)
       # TODO: make same fixes made to chain here
       if (nrow(revere_task$data) != nrow(predictions)) {
         # Gather validation indexes:

--- a/R/Lrnr_cv.R
+++ b/R/Lrnr_cv.R
@@ -371,7 +371,7 @@ Lrnr_cv <- R6Class(
         list(
           index = index,
           fold_index = rep(fold_index(), length(index)),
-          predictions = data.table(predictions)
+          predictions = as.data.table(predictions)
         )
       }
 

--- a/R/Lrnr_cv.R
+++ b/R/Lrnr_cv.R
@@ -392,9 +392,14 @@ Lrnr_cv <- R6Class(
 
       predictions <- aorder(preds, order(results$index, results$fold_index))
 
-      # don't convert to vector if learner is stack, as stack won't
+      
+       # don't convert to vector if learner is stack, as stack won't
       if ((ncol(predictions) == 1) && !inherits(self$params$learner, "Stack")) {
-        predictions <- unlist(predictions)
+        # if packed_predictions dont unlist
+        if(is.data.table(predictions)) predictions <- as.matrix(predictions)
+        if(!inherits(predictions[[1]], "packed_predictions")) {
+          predictions <- as.vector(predictions)
+        }
       }
       return(predictions)
     },

--- a/R/Lrnr_gam.R
+++ b/R/Lrnr_gam.R
@@ -77,7 +77,7 @@ Lrnr_gam <- R6Class(
     }
   ),
   private = list(
-    .properties = c("continuous", "binomial"),
+    .properties = c("continuous", "binomial", "weights"),
     .train = function(task) {
       # load args
       args <- self$params
@@ -87,6 +87,7 @@ Lrnr_gam <- R6Class(
       Y <- data.frame(outcome_type$format(task$Y))
       colnames(Y) <- task$nodes$outcome
       args$data <- cbind(task$X, Y)
+      args$weights <- task$weights
       ## family
       if (is.null(args$family)) {
         if (outcome_type$type == "continuous") {

--- a/R/survival_utils.R
+++ b/R/survival_utils.R
@@ -32,11 +32,16 @@ pooled_hazard_task <- function(task, trim = TRUE) {
   repeated_data <- underlying_data[index, ]
   new_folds <- origami::id_folds_to_folds(task$folds, index)
 
-  repeated_task <- task$next_in_chain(
-    column_names = column_names,
-    data = repeated_data, id = "id",
-    folds = new_folds
-  )
+  nodes <- task$nodes
+  nodes$id <- "id"
+  repeated_task <- sl3_Task$new(repeated_data, column_names = column_names, nodes = task$nodes, folds = new_folds, outcome_levels = outcome_levels, outcome_type = task$outcome_type$type)
+
+  # The below errors when used in CV due to the stored row index not being reset in next_in_chain.
+  #repeated_task <- task$next_in_chain(
+   # column_names = column_names,
+    #data = repeated_data, id = "id",
+    #folds = new_folds
+  #)
 
   # make bin indicators
   bin_number <- rep(level_index, each = task$nrow)


### PR DESCRIPTION
Previously, the following code, which contains a Stack of one learner, outputted a data.table containing NULLs with some entries a list of some subset of predictions.

This bug is fixed here by replacing data.table(preds) with as.data.table(preds) in the .predict function of Lrnr_cv.
As a note here, I think we should move away from using `data.table(object)` unless we deliberately want to have a data.table containing lists (e..g, as with packed predictions). In other cases, `as.data.table` should be used.
 
```
n <- 500
W <- runif(n, -1 , 1)
Y <- rbinom(n, 1, plogis(W))
task <- sl3_Task$new(data.table(W,Y), covariates = "W", outcome = "Y") 
Lrnr_cv$new(Stack$new(Lrnr_glm$new() ))$train(task)$predict(task)
```