### PR TITLE
Lrnr_density_semiparametric bug: density estimates don't always integrate to 1

### DIFF
--- a/R/Lrnr_density_semiparametric.R
+++ b/R/Lrnr_density_semiparametric.R
@@ -124,8 +124,18 @@ Lrnr_density_semiparametric <- R6Class(
         min_obs_error <- 2 * min(se_task$Y)
         var_fit <- var_learner$train(se_task)
         var_preds <- var_fit$predict()
-        var_preds[var_preds < 0] <- min_obs_error
-        sd_preds <- sqrt(var_preds)
+        
+        # calculate a practical floor for error variance, called squared tolerance
+        errors_sd <- sd(errors)
+        tol2   <- (0.1 * errors_sd)^2  
+        
+        # replace any NA or too-small var_pred with tol2
+        var_preds_clean <- ifelse(
+          is.na(var_preds) | var_preds < 0,
+          tol2,
+          var_preds
+        )
+        sd_preds <- sqrt(var_preds_clean)
         errors <- errors / sd_preds
       } else {
         var_fit <- NULL

--- a/tests/testthat/test-density-semiparametric.R
+++ b/tests/testthat/test-density-semiparametric.R
@@ -56,3 +56,109 @@ test_that("Lrnr_density_semiparametric works", {
   # x_samp <- sample(x_grid, 20)
   # ggplot(long[x%in%x_samp],aes(x=y,y=value,color=variable))+geom_line()+facet_wrap(~round(x,5),scales="free_x")+theme_bw()+coord_flip()
 })
+
+
+# Densities should integrate to 1 --- 
+# 
+#
+# the core logic of this test is that a (conditional) density model fit by
+# Lrnr_density_semiparametric (given predictors) should integrate to 1 as it
+# should be an estimate of a probability density function.
+# 
+# 
+test_that("Lrnr_density_semiparametric produces densities that integrate to 1", {
+  
+  # fit a heteroskedastic density model (using glm for the conditional mean
+  # component, and glm for the conditional variance component), fix a vector of
+  # covariates, and integrate the density across a region of plausible outcome
+  # values.
+  # 
+  # this is in a function so we can repeat the test on at least two different
+  # datasets.
+  fit_a_heteroskedastic_density_model_and_integrate_area_under_density_curve <-
+    function(
+      df,
+      covariates,
+      outcome) {
+      
+    task <- sl3_Task$new(
+      df,
+      covariates = covariates,
+      outcome = outcome)
+    
+    heteroskedastic_glm_glm_sl3 <- Lrnr_density_semiparametric$new(
+      mean_learner = make_learner(Lrnr_glm),
+      var_learner = make_learner(Lrnr_glm)
+    )
+    
+    Lrnr_glm_heteroskedastic_fit <- heteroskedastic_glm_glm_sl3$train(task)
+    Lrnr_glm_heteroskedastic_predictor <- Lrnr_glm_heteroskedastic_fit$predict
+    
+    
+    f_heteroskedastic_density <- function(ys) {
+      # take the first row to use to fix all the covariates
+      x <- df[1,,drop=FALSE]
+      # replicate it for each point at which we will evaluate it to integrate it 
+      newdata <- dplyr::bind_rows(replicate(n = length(ys), expr = x, simplify = FALSE))
+      # replace the outcome with each of the values to evaluate the density at
+      newdata[outcome] <- ys
+      
+      new_task <- sl3::sl3_Task$new(
+        data = newdata,
+        covariates = covariates,
+        outcome = outcome)
+        
+      Lrnr_glm_heteroskedastic_predictor(new_task)
+    }
+    
+    # setup a range across which we will integrate
+    lower_than_min <- min(df[[outcome]]) - 10*sd(df[[outcome]])
+    higher_than_max <- max(df[[outcome]]) + 10*sd(df[[outcome]])
+    
+    # plotting code for a sanity/face-value check:
+    # outcome_values <- seq(lower_than_min, higher_than_max, length.out = 10000)
+    # density_values <- f_heteroskedastic_density(outcome_values)
+    # plot(outcome_values, density_values, type = 'l')
+    
+    # integrate the density given the covariates in the first row of df
+    integrated_area_under_density_curve <-
+      integrate(f_heteroskedastic_density,
+                lower = lower_than_min,
+                upper = higher_than_max)
+    
+    return(integrated_area_under_density_curve$value)
+  }
+    
+  # the following test fits a conditional density model to the mtcars dataset 
+  # using hp as the outcome and the other continuous variables 
+  # as the covariates.
+  
+  mtcars_integrated_area_under_density <-
+    fit_a_heteroskedastic_density_model_and_integrate_area_under_density_curve(
+      df = mtcars,
+      covariates = c('mpg', 'disp', 'drat', 'wt', 'qsec'),
+      outcome = 'hp'
+    )
+  
+  testthat::expect_gt(mtcars_integrated_area_under_density, .9)
+  testthat::expect_lt(mtcars_integrated_area_under_density, 1.1)
+  
+  # the following test fits a conditional density model to the MASS::Boston
+  # dataset using medv as the outcome and other continuous variables as the
+  # covariates.
+  # 
+  # sl3 imports ggplot2 and ggplot2 imports MASS so no additional dependency 
+  # is added by relying on MASS::Boston in this test. 
+  Boston_integrated_area_under_density <-
+    fit_a_heteroskedastic_density_model_and_integrate_area_under_density_curve(
+      df = MASS::Boston,
+      covariates = c('crim', 'indus', 'nox', 'rm', 'age', 'dis', 'tax'),
+      outcome = 'medv'
+    )
+  
+  testthat::expect_gt(Boston_integrated_area_under_density, .9)
+  testthat::expect_lt(Boston_integrated_area_under_density, 1.1)
+  
+  
+})
+


### PR DESCRIPTION
In some uses, I have found that the density models that `Lrnr_density_semiparametric` don't pass a simple test:  

Does the area under the density curve estimated integrate to 1, as it should be for a probability density model? 

### what's going on

In the training step, on [line 124](https://github.com/tlverse/sl3/blob/0e8f2365bcbe54010b8120c04a7a2dcfc8119227/R/Lrnr_density_semiparametric.R#L124), `min_obs_error <- 2 * min(se_task$Y)` can be arbitrarily small. 

For context, the `se_task$Y` is a regression of the squared errors from the conditional mean model on the predictors.  So if the conditional mean model makes low error predictions, nothing stops this `min_obs_error` from being extremely small. 

Later on, the `min_obs_error` value is used to replace problematic values in the `var_preds` object on [line 127](https://github.com/tlverse/sl3/blob/0e8f2365bcbe54010b8120c04a7a2dcfc8119227/R/Lrnr_density_semiparametric.R#L127).  The `var_preds` object is then `sqrt()`ed and used to scale the errors (`errors <- errors / sd_preds` on line 129) to make them constant variance before fitting an `approx(density(...))` to the scaled error distribution. 

When `sd_preds` is very small (as can happen from the `min_obs_error` being used), these scaled errors are pushed towards +/- infinity unstably and this seems to mess up the density estimation. 

For reference, what this does to the density estimates is it seems to make them more coarsely discretized, resulting in the area under the density curve being noisier and more prone to being far from 1. 

<img width="1356" height="784" alt="image" src="https://github.com/user-attachments/assets/711a822c-47cd-4751-8fb0-a14093d99e3a" />


### proposed bugfix 

The core issue is that `min_obs_error` is too small.  Rather than using the minimum of the squared error, I have tried using the square of 10% of the standard deviation of the prediction errors from the conditional mean model.  My reasoning is that we do want to replace the values where `var_preds < 0` with something small, but not too/arbitrarily small. 

The proposed bugfix included in this PR result in the tests (also included in this PR) now passing, and the density curve estimated is a lot smoother by comparison, yielding area-under-the-curve very close to 1. 

<img width="1362" height="780" alt="image" src="https://github.com/user-attachments/assets/d6318904-b41e-446b-8b25-243c6af11b35" />

### test to illustrate the bug 

The core logic of the tests is this: 

  1. Fit a `Lrnr_density_semiparametric` model to a dataset with an outcome `Y` for which we estimate the density and predictors `X1` through `Xn`.  Say the training dataset is `data`.  Call the fit model `density_model`.
  3. Take an arbitrary row of the dataset, say `data[1,]`. 
  4. For that row, fix the values of `X1` through `Xn` and form a grid of possible `Y` values — say between `min(data$Y) - 10*sd(data$Y)` to `max(data$Y) + 10*sd(data$Y)`. 
  5. When we integrate the density predictions across the range of possible `Y` values using `density_model` the fixed values of `data[1,X1], ..., data[1, Xn]` as the predictors, we are evaluating whether or not $\hat f_{Y}(y | X_1, ..., X_n)$ (the estimated density model) integrates to 1 when the conditioning variables are fixed, and this test fails for some datasets.

In my case, I found that this was fine for the models I fit on the `mtcars` dataset, but using the `MASS::Boston` dataset, I ran into lots of situations where this test failed.  I've included an example from each dataset in the tests I wrote. 