### PR TITLE
Update add_interaction() function, ranger wrapper, and xgboost wrapper

### DIFF
--- a/R/Lrnr_ranger.R
+++ b/R/Lrnr_ranger.R
@@ -118,9 +118,9 @@ Lrnr_ranger <- R6Class(
       if (task$has_node("weights")) {
         args$case.weights <- task$weights
       }
+      # Preserve raw data frame
       Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
       data_in <- cbind(task$Y, Xdf)
-      # data_in <- cbind(task$Y, task$X)
       colnames(data_in)[1] <- task$nodes$outcome
       args$data <- data_in
       args$dependent.variable.name <- task$nodes$outcome
@@ -129,6 +129,8 @@ Lrnr_ranger <- R6Class(
       return(fit_object)
     },
     .predict = function(task) {
+
+      # Preserve raw data frame
       Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
       
       # extract numeric predictions from custom class ranger.prediction

--- a/R/Lrnr_ranger.R
+++ b/R/Lrnr_ranger.R
@@ -118,7 +118,9 @@ Lrnr_ranger <- R6Class(
       if (task$has_node("weights")) {
         args$case.weights <- task$weights
       }
-      data_in <- cbind(task$Y, task$X)
+      Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
+      data_in <- cbind(task$Y, Xdf)
+      # data_in <- cbind(task$Y, task$X)
       colnames(data_in)[1] <- task$nodes$outcome
       args$data <- data_in
       args$dependent.variable.name <- task$nodes$outcome
@@ -127,10 +129,12 @@ Lrnr_ranger <- R6Class(
       return(fit_object)
     },
     .predict = function(task) {
+      Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
+      
       # extract numeric predictions from custom class ranger.prediction
       predictions <- stats::predict(
         private$.fit_object,
-        data = task$X,
+        data = Xdf,
         type = "response",
         num.threads = self$params$num.threads
       )

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -98,7 +98,7 @@ Lrnr_xgboost <- R6Class(
       # Preserve raw data frame
       Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
       
-      args$data <- try(xgboost::xgb.DMatrix(Xdf, label = Y), silent = TRUE)
+      args$data <- try(xgboost::xgb.DMatrix(Xdf, label = Y)) # , silent = TRUE
 
       factor_levels <- lapply(Xdf, function(z) if (is.factor(z)) levels(z) else NULL)
 
@@ -116,7 +116,7 @@ Lrnr_xgboost <- R6Class(
         family <- outcome_type$glm_family(return_object = TRUE)
         link_fun <- args$family$linkfun
         offset <- task$offset_transformed(link_fun)
-        try(xgboost::setinfo(args$data, "base_margin", offset), silent = TRUE)
+        try(xgboost::setinfo(args$data, "base_margin", offset)) #, silent = TRUE
       } else {
         link_fun <- NULL
       }

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -53,9 +53,8 @@
 #'
 #' # get feature importance from fitted model
 #' xgb_varimp <- xgb_fit$importance()
-Lrnr_xgboost <- R6Class(
+Lrnr_xgboost <- R6::R6Class(
   classname = "Lrnr_xgboost", inherit = Lrnr_base,
-  portable = TRUE, class = TRUE,
   public = list(
     initialize = function(nrounds = 20, nthread = 1, ...) {
       params <- args_to_list()
@@ -63,136 +62,179 @@ Lrnr_xgboost <- R6Class(
     },
     importance = function(...) {
       self$assert_trained()
-
-      # initiate argument list for xgboost::xgb.importance
       args <- list(...)
       args$model <- self$fit_object
-
-      # calculate importance metrics, already sorted by decreasing importance
-      importance_result <- call_with_args(xgboost::xgb.importance, args)
-      rownames(importance_result) <- importance_result[["Feature"]]
-      return(importance_result)
+      imp <- call_with_args(xgboost::xgb.importance, args)
+      rownames(imp) <- imp[["Feature"]]
+      imp
     }
   ),
   private = list(
-    .properties = c(
-      "continuous", "binomial", "categorical", "weights",
-      "offset", "importance"
-    ),
+    .properties = c("continuous", "binomial", "categorical", "weights", "offset", "importance"),
+
+    .audit_df = function(df, head_levels = 4L) {
+      cls <- vapply(df, function(z) paste(class(z), collapse = ","), character(1))
+      is_char <- vapply(df, is.character, logical(1))
+      is_fac  <- vapply(df, is.factor,   logical(1))
+      lvl_n   <- vapply(df, function(z) if (is.factor(z)) length(levels(z)) else NA_integer_, integer(1))
+      lvl_ex  <- vapply(df, function(z) {
+        if (is.factor(z)) paste(utils::head(levels(z), head_levels), collapse = "|") else ""
+      }, character(1))
+      data.frame(
+        column = names(df),
+        class  = cls,
+        is_character = is_char,
+        is_factor    = is_fac,
+        n_levels     = lvl_n,
+        ex_levels    = lvl_ex,
+        row.names = NULL,
+        check.names = FALSE
+      )
+    },
+
+    .stop_with_context = function(msg, Xdf, err = NULL) {
+      audit <- private$.audit_df(Xdf)
+      bad_chars <- audit$column[audit$is_character]
+      cat("=== XGBoost DMatrix construction failed ===\n")
+      cat("Reason:", msg, "\n")
+      if (!is.null(err)) cat("xgboost says:", conditionMessage(err), "\n")
+      cat("Data summary: ", nrow(Xdf), " rows x ", ncol(Xdf), " cols\n", sep = "")
+      if (length(bad_chars)) {
+        cat("Character columns (must convert to factor or numeric):\n  - ",
+            paste(bad_chars, collapse = ", "), "\n", sep = "")
+      }
+      fac_rows <- audit[audit$is_factor, ]
+      if (nrow(fac_rows)) {
+        cat("Factor columns and levels (first few):\n")
+        utils::capture.output(print(fac_rows[, c("column","n_levels","ex_levels")], row.names = FALSE)) |>
+          paste(collapse = "\n") |> cat("\n")
+      }
+      stop(msg, call. = FALSE)
+    },
+
     .train = function(task) {
       args <- self$params
-
-      verbose <- args$verbose
-      if (is.null(verbose)) {
-        verbose <- getOption("sl3.verbose")
-      }
+      verbose <- if (is.null(args$verbose)) getOption("sl3.verbose") else args$verbose
       args$verbose <- as.integer(verbose)
 
-      # set up outcome
+      # outcome
       outcome_type <- self$get_outcome_type(task)
       Y <- outcome_type$format(task$Y)
-      if (outcome_type$type == "categorical") {
-        Y <- as.numeric(Y) - 1
-      }
+      if (outcome_type$type == "categorical") Y <- as.numeric(Y) - 1L
 
-      # Preserve raw data frame
+      # covariates as raw data.frame (no factor expansion)
       Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
-      
-      args$data <- try(xgboost::xgb.DMatrix(Xdf, label = Y)) # , silent = TRUE
+      stopifnot(is.data.frame(Xdf))
 
-      factor_levels <- lapply(Xdf, function(z) if (is.factor(z)) levels(z) else NULL)
-
-      # specify weights
-      if (task$has_node("weights")) {
-        try(xgboost::setinfo(args$data, "weight", task$weights), silent = TRUE)
+      # convert any characters to factor (xgboost supports factor directly via xgb.DMatrix)
+      if (any(vapply(Xdf, is.character, logical(1)))) {
+        Xdf[] <- lapply(Xdf, function(z) if (is.character(z)) factor(z) else z)
       }
 
-      # specify offset
+      # Build DMatrix with hard check + diagnostics
+      dm <- try(xgboost::xgb.DMatrix(data = Xdf, label = Y,
+                                     feature_names = colnames(Xdf)), silent = TRUE)
+      if (inherits(dm, "try-error") || !inherits(dm, "xgb.DMatrix")) {
+        private$.stop_with_context("xgb.DMatrix() did not return an xgb.DMatrix", Xdf, err = attr(dm, "condition"))
+      }
+
+      # weights
+      if (task$has_node("weights")) {
+        try(xgboost::setinfo(dm, "weight", task$weights), silent = TRUE)
+      }
+
+      # offset / base_margin
       if (task$has_node("offset")) {
         if (outcome_type$type == "categorical") {
-          # TODO: fix
           stop("offsets not yet supported for outcome_type='categorical'")
         }
-        family <- outcome_type$glm_family(return_object = TRUE)
+        family   <- outcome_type$glm_family(return_object = TRUE)
         link_fun <- args$family$linkfun
-        offset <- task$offset_transformed(link_fun)
-        try(xgboost::setinfo(args$data, "base_margin", offset)) #, silent = TRUE
+        offset   <- task$offset_transformed(link_fun)
+        try(xgboost::setinfo(dm, "base_margin", offset), silent = TRUE)
       } else {
         link_fun <- NULL
       }
 
-      # specify objective if it's NULL to avoid xgb warnings
+      # reasonable default objective
       if (is.null(args$objective)) {
         if (outcome_type$type == "binomial") {
-          args$objective <- "binary:logistic"
-          args$eval_metric <- "logloss"
+          args$objective <- "binary:logistic"; args$eval_metric <- "logloss"
         } else if (outcome_type$type == "quasibinomial") {
           args$objective <- "reg:logistic"
         } else if (outcome_type$type == "categorical") {
-          args$objective <- "multi:softprob"
-          args$eval_metric <- "mlogloss"
+          args$objective <- "multi:softprob"; args$eval_metric <- "mlogloss"
           args$num_class <- as.integer(length(outcome_type$levels))
+        } else {
+          # continuous
+          if (is.null(args$eval_metric)) args$eval_metric <- "rmse"
         }
       }
 
-      args$watchlist <- list(train = args$data)
-      fit_object <- call_with_args(xgboost::xgb.train, args,
-        keep_all = TRUE,
-        ignore = "formula"
-      )
-      fit_object$training_offset <- task$has_node("offset")
-      fit_object$link_fun <- link_fun
-      fit_object$sl3_factor_levels <- factor_levels 
+      args$data <- dm
+      args$watchlist <- list(train = dm)
 
-      return(fit_object)
+      fit_object <- call_with_args(xgboost::xgb.train, args, keep_all = TRUE, ignore = "formula")
+      fit_object$training_offset   <- task$has_node("offset")
+      fit_object$link_fun          <- link_fun
+      fit_object$sl3_feature_names <- colnames(Xdf)
+      fit_object$sl3_factor_levels <- lapply(Xdf, function(z) if (is.factor(z)) levels(z) else NULL)
+      fit_object
     },
+
     .predict = function(task = NULL) {
-      fit_object <- private$.fit_object
+      fit <- private$.fit_object
 
-      # Preserve raw data frame
+      # raw df
       Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
-      
-      # relevel factors to training levels (keep order identical to train)
+      stopifnot(is.data.frame(Xdf))
+
+      # relevel factors to training levels; also coerce stray characters
+      tr_lvls_list <- fit$sl3_factor_levels
       for (nm in names(Xdf)) {
-        tr_lvls <- fit_object$sl3_factor_levels[[nm]]
-        Xdf[[nm]] <- factor(Xdf[[nm]], levels = tr_lvls)
-      }
-      
-      # convert to xgb.DMatrix
-      xgb_data <- try(xgboost::xgb.DMatrix(Xdf), silent = TRUE)
-
-      # incorporate offset, if it wasspecified in training
-      if (self$fit_object$training_offset) {
-        offset <- task$offset_transformed(
-          self$fit_object$link_fun,
-          for_prediction = TRUE
-        )
-        try(xgboost::setinfo(xgb_data, "base_margin", offset), silent = TRUE)
-      }
-
-      # incorporate ntreelimit, if training model was not a gblinear-based fit
-      ntreelimit <- 0
-      if (!is.null(fit_object[["best_ntreelimit"]]) &
-        !("gblinear" %in% fit_object[["params"]][["booster"]])) {
-        ntreelimit <- fit_object[["best_ntreelimit"]]
-      }
-
-      predictions <- rep.int(list(numeric()), 1)
-      if (nrow(Xmat) > 0) {
-        # will generally return vector, needs to be put into data.table column
-        predictions <- stats::predict(
-          fit_object,
-          newdata = xgb_data, ntreelimit = ntreelimit, reshape = TRUE
-        )
-
-        if (private$.training_outcome_type$type == "categorical") {
-          # pack predictions in a single column
-          predictions <- pack_predictions(predictions)
+        if (is.character(Xdf[[nm]])) Xdf[[nm]] <- factor(Xdf[[nm]])
+        tr_lvls <- tr_lvls_list[[nm]]
+        if (!is.null(tr_lvls) && is.factor(Xdf[[nm]])) {
+          Xdf[[nm]] <- factor(Xdf[[nm]], levels = tr_lvls)
         }
       }
 
-      return(predictions)
+      # reorder columns to training order (critical)
+      tr_names <- fit$sl3_feature_names
+      ord <- match(tr_names, colnames(Xdf))
+      if (anyNA(ord)) {
+        missing_cols <- tr_names[is.na(ord)]
+        msg <- paste0("Prediction data is missing ", length(missing_cols),
+                      " training column(s): ", paste(missing_cols, collapse = ", "))
+        private$.stop_with_context(msg, Xdf, err = NULL)
+      }
+      Xdf <- Xdf[, ord, drop = FALSE]
+
+      # DMatrix (with check)
+      dm <- try(xgboost::xgb.DMatrix(data = Xdf, feature_names = colnames(Xdf)), silent = TRUE)
+      if (inherits(dm, "try-error") || !inherits(dm, "xgb.DMatrix")) {
+        private$.stop_with_context("xgb.DMatrix() failed during predict()", Xdf, err = attr(dm, "condition"))
+      }
+
+      # optional offset
+      if (fit$training_offset) {
+        offset <- task$offset_transformed(fit$link_fun, for_prediction = TRUE)
+        try(xgboost::setinfo(dm, "base_margin", offset), silent = TRUE)
+      }
+
+      # best_ntreelimit if present
+      ntreelimit <- 0
+      if (!is.null(fit[["best_ntreelimit"]]) && !("gblinear" %in% fit[["params"]][["booster"]])) {
+        ntreelimit <- fit[["best_ntreelimit"]]
+      }
+
+      if (nrow(Xdf) == 0) return(numeric(0))
+
+      preds <- stats::predict(fit, newdata = dm, ntreelimit = ntreelimit, reshape = TRUE)
+      if (private$.training_outcome_type$type == "categorical") preds <- pack_predictions(preds)
+      preds
     },
+
     .required_packages = c("xgboost")
   )
 )

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -212,7 +212,7 @@ Lrnr_xgboost <- R6Class(
       if (private$.training_outcome_type$type == "categorical") {
         k <- length(private$.training_outcome_type$levels)
         predictions <- matrix(predictions, ncol = k, byrow = TRUE)
-        colnames(predictions) <- private$.training_outcome_type$levels
+        # colnames(predictions) <- private$.training_outcome_type$levels
         
         # pack predictions in a single column
         predictions <- pack_predictions(predictions)

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -106,7 +106,7 @@ Lrnr_xgboost <- R6Class(
       if (nrow(Xmat) != nrow(task$X) & ncol(Xmat) == nrow(task$X)) {
         Xmat <- t(Xmat)
       }
-      args$data <- try(xgboost::xgb.DMatrix(Xmat, label = Y), silent = TRUE)
+      args$data <- try(xgboost::xgb.DMatrix(Xdf, label = Y), silent = TRUE)
 
       # specify weights
       if (task$has_node("weights")) {
@@ -169,7 +169,7 @@ Lrnr_xgboost <- R6Class(
       }
       stopifnot(nrow(Xmat_ord) == nrow(Xmat))
       # convert to xgb.DMatrix
-      xgb_data <- try(xgboost::xgb.DMatrix(Xmat_ord), silent = TRUE)
+      xgb_data <- try(xgboost::xgb.DMatrix(Xdf), silent = TRUE)
 
       # incorporate offset, if it wasspecified in training
       if (self$fit_object$training_offset) {

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -207,15 +207,15 @@ Lrnr_xgboost <- R6Class(
         xgboost::setinfo(xgb_data, "base_margin", offset)
       }
     
-      # 4) Predict with NO limit (uses all trees; if model had ES and you use xgboost::xgboost
-      #    class, its high-level predict would default to the best iteration. For xgb.Booster,
-      #    just omit limits unless you really need a subset.)
-      preds <- stats::predict(booster, newdata = xgb_data)
+      predictions <- stats::predict(booster, newdata = xgb_data)
     
-      # 5) Reshape for multiclass
       if (private$.training_outcome_type$type == "categorical") {
         k <- length(private$.training_outcome_type$levels)
-        preds <- matrix(preds, ncol = k, byrow = TRUE)
+        predictions <- matrix(predictions, ncol = k, byrow = TRUE)
+        colnames(predictions) <- private$.training_outcome_type$levels
+        
+        # pack predictions in a single column
+        predictions <- pack_predictions(predictions)
       }
       return(preds)
     },

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -131,6 +131,8 @@ Lrnr_xgboost <- R6::R6Class(
         Xdf[] <- lapply(Xdf, function(z) if (is.character(z)) factor(z) else z)
       }
 
+      print(is.data.frame(Xdf))
+
       # Build DMatrix with hard check + diagnostics
       dm <- try(xgboost::xgb.DMatrix(data = Xdf, feature_names = colnames(Xdf)), silent = TRUE)
       if (inherits(dm, "try-error") || !inherits(dm, "xgb.DMatrix")) {

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -210,14 +210,14 @@ Lrnr_xgboost <- R6Class(
       predictions <- stats::predict(booster, newdata = xgb_data)
     
       if (private$.training_outcome_type$type == "categorical") {
-        k <- length(private$.training_outcome_type$levels)
-        predictions <- matrix(predictions, ncol = k, byrow = TRUE)
+        # k <- length(private$.training_outcome_type$levels)
+        # predictions <- matrix(predictions, ncol = k, byrow = TRUE)
         # colnames(predictions) <- private$.training_outcome_type$levels
         
         # pack predictions in a single column
         predictions <- pack_predictions(predictions)
       }
-      return(preds)
+      return(predictions)
     },
     .required_packages = c("xgboost")
   )

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -212,7 +212,7 @@ Lrnr_xgboost <- R6Class(
       if (private$.training_outcome_type$type == "categorical") {
         k <- length(private$.training_outcome_type$levels)
         predictions <- matrix(predictions, ncol = k, byrow = TRUE)
-        # colnames(predictions) <- private$.training_outcome_type$levels
+        colnames(predictions) <- private$.training_outcome_type$levels
         
         # pack predictions in a single column
         predictions <- pack_predictions(predictions)

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -132,8 +132,7 @@ Lrnr_xgboost <- R6::R6Class(
       }
 
       # Build DMatrix with hard check + diagnostics
-      dm <- try(xgboost::xgb.DMatrix(data = Xdf, label = Y,
-                                     feature_names = colnames(Xdf)), silent = TRUE)
+      dm <- try(xgboost::xgb.DMatrix(data = Xdf, feature_names = colnames(Xdf)), silent = TRUE)
       if (inherits(dm, "try-error") || !inherits(dm, "xgb.DMatrix")) {
         private$.stop_with_context("xgb.DMatrix() did not return an xgb.DMatrix", Xdf, err = attr(dm, "condition"))
       }

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -210,8 +210,8 @@ Lrnr_xgboost <- R6Class(
       predictions <- stats::predict(booster, newdata = xgb_data)
     
       if (private$.training_outcome_type$type == "categorical") {
-        # k <- length(private$.training_outcome_type$levels)
-        # predictions <- matrix(predictions, ncol = k, byrow = TRUE)
+        k <- length(private$.training_outcome_type$levels)
+        predictions <- matrix(predictions, ncol = k, byrow = TRUE)
         # colnames(predictions) <- private$.training_outcome_type$levels
         
         # pack predictions in a single column

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -95,8 +95,11 @@ Lrnr_xgboost <- R6Class(
         Y <- as.numeric(Y) - 1
       }
 
+      # Preserve raw data frame
+      Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
+      
       # set up predictor data
-      Xmat <- as.matrix(task$X)
+      Xmat <- as.matrix(Xdf)
       if (is.integer(Xmat)) {
         Xmat[, 1] <- as.numeric(Xmat[, 1])
       }
@@ -151,8 +154,11 @@ Lrnr_xgboost <- R6Class(
     .predict = function(task = NULL) {
       fit_object <- private$.fit_object
 
+      # Preserve raw data frame
+      Xdf <- task$get_data(columns = task$nodes$covariates, expand_factors = FALSE)
+      
       # set up test data for prediction
-      Xmat <- as.matrix(task$X)
+      Xmat <- as.matrix(Xdf)
       if (is.integer(Xmat)) {
         Xmat[, 1] <- as.numeric(Xmat[, 1])
       }

--- a/R/Lrnr_xgboost.R
+++ b/R/Lrnr_xgboost.R
@@ -226,7 +226,7 @@ Lrnr_xgboost <- R6Class(
       }
     
       return(preds)
-    }
+    },
     .required_packages = c("xgboost")
   )
 )


### PR DESCRIPTION
This PR includes three updates aimed at improving usability and preventing bugs:

---


**1. Fix to add_interaction(): avoid incorrect interaction term creation**

The original add_interaction() function (used in Lrnr_define_interaction) could accidentally generate unintended interaction terms when variable names partially overlap. For example, if the dataset includes both age and percentage, requesting interactions with age could also unintentionally include percentage, due to the use of grep() for partial matching.

This has been fixed by switching to explicit name matching to avoid such cases.

---

**2. Update to ranger wrapper: support for factor-splitting**

The updated ranger wrapper now supports the newer version of ranger that allows direct splitting on factor predictors, avoiding the need for manual one-hot encoding.

---

**3. Update to xgboost wrapper: support for factor-splitting (requires latest version)**

This is a more substantial update, reflecting recent changes in xgboost. The wrapper now supports direct splitting on factor variables as well, but requires the user to install the development version from r-universe. Instructions:

>   
>   1. Download from r-universe:
>   ```
>   https://dmlc.r-universe.dev/xgboost￼
>   ```
>   
>   2. Install downloaded package:
>   ```
>   install.packages("~/Downloads/xgboost_3.1.0.1.tgz", 
>                    repos = NULL, 
>                    type = "source")
>   ```

---

Please review the changes and let me know if you have any questions or suggestions.

Best,
Jesse